### PR TITLE
Assets controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,6 +2433,10 @@
         "tape": "^4.6.3"
       }
     },
+    "eth-contract-metadata": {
+      "version": "github:estebanmino/eth-contract-metadata#fedcbae5b6fa1d03ecbfba7000224c7434a56619",
+      "from": "github:estebanmino/eth-contract-metadata#master"
+    },
     "eth-hd-keyring": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eth-hd-keyring/-/eth-hd-keyring-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "await-semaphore": "^0.1.3",
     "eth-block-tracker": "git://github.com/metamask/eth-block-tracker.git#3.0.1-subscription-fix",
+    "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#master",
     "eth-json-rpc-infura": "^3.1.2",
     "eth-keyring-controller": "^4.0.0",
     "eth-phishing-detect": "^1.1.13",

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -1,7 +1,7 @@
 import { stub } from 'sinon';
 import AssetsController from './AssetsController';
 
-describe('PreferencesController', () => {
+describe('AssetsController', () => {
 	let assetsController: AssetsController;
 	beforeEach(() => {
 		assetsController = new AssetsController();

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -1,0 +1,36 @@
+import AssetsController from './AssetsController';
+
+describe('PreferencesController', () => {
+	let assetsController: AssetsController;
+	beforeEach(() => {
+		assetsController = new AssetsController();
+	});
+
+	it('should set default state', () => {
+		expect(assetsController.state).toEqual({
+			collectibles: [],
+			tokens: []
+		});
+	});
+
+	it('should add token', () => {
+		assetsController.addToken('foo', 'bar', 2);
+		expect(assetsController.state.tokens[0]).toEqual({
+			address: '0xfoO',
+			decimals: 2,
+			symbol: 'bar'
+		});
+		assetsController.addToken('foo', 'baz', 2);
+		expect(assetsController.state.tokens[0]).toEqual({
+			address: '0xfoO',
+			decimals: 2,
+			symbol: 'baz'
+		});
+	});
+
+	it('should remove token', () => {
+		assetsController.addToken('foo', 'bar', 2);
+		assetsController.removeToken('foo');
+		expect(assetsController.state.tokens.length).toBe(0);
+	});
+});

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -124,7 +124,7 @@ describe('AssetsController', () => {
 	});
 
 	it('should add collectible', async () => {
-		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		stub(assetsController, 'requestNFTCustomInformation' as any).returns({ name: 'name', image: 'url' });
 		await assetsController.addCollectible('foo', 1234);
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0xfoO',
@@ -139,7 +139,7 @@ describe('AssetsController', () => {
 		const network = new NetworkController();
 		const firstAddress = '0x123';
 		const secondAddress = '0x321';
-		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		stub(assetsController, 'requestNFTCustomInformation' as any).returns({ name: 'name', image: 'url' });
 		/* tslint:disable-next-line:no-unused-expression */
 		new ComposableController([assetsController, network, preferences]);
 		preferences.update({ selectedAddress: firstAddress });
@@ -160,7 +160,7 @@ describe('AssetsController', () => {
 		const network = new NetworkController();
 		const firstNetworkType = 'rinkeby';
 		const secondNetworkType = 'ropsten';
-		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		stub(assetsController, 'requestNFTCustomInformation' as any).returns({ name: 'name', image: 'url' });
 		/* tslint:disable-next-line:no-unused-expression */
 		new ComposableController([assetsController, network, preferences]);
 		network.update({ provider: { type: firstNetworkType } });
@@ -177,7 +177,7 @@ describe('AssetsController', () => {
 	});
 
 	it('should remove collectible', () => {
-		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		stub(assetsController, 'requestNFTCustomInformation' as any).returns({ name: 'name', image: 'url' });
 		assetsController.addCollectible('0xfoO', 1234);
 		assetsController.removeCollectible('0xfoO', 1234);
 		expect(assetsController.state.collectibles.length).toBe(0);
@@ -186,7 +186,7 @@ describe('AssetsController', () => {
 	it('should remove collectible by selected address', async () => {
 		const preferences = new PreferencesController();
 		const network = new NetworkController();
-		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		stub(assetsController, 'requestNFTCustomInformation' as any).returns({ name: 'name', image: 'url' });
 		const firstAddress = '0x123';
 		const secondAddress = '0x321';
 		/* tslint:disable-next-line:no-unused-expression */
@@ -209,7 +209,7 @@ describe('AssetsController', () => {
 	it('should remove collectible by provider type', async () => {
 		const preferences = new PreferencesController();
 		const network = new NetworkController();
-		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		stub(assetsController, 'requestNFTCustomInformation' as any).returns({ name: 'name', image: 'url' });
 		const firstNetworkType = 'rinkeby';
 		const secondNetworkType = 'ropsten';
 		/* tslint:disable-next-line:no-unused-expression */
@@ -231,27 +231,30 @@ describe('AssetsController', () => {
 	});
 
 	it('should not add duplicated collectible', async () => {
-		const func = stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		const func = stub(assetsController, 'requestNFTCustomInformation' as any).returns({
+			image: 'url',
+			name: 'name'
+		});
 		await assetsController.addCollectible('foo', 1234);
 		await assetsController.addCollectible('foo', 1234);
 		expect(assetsController.state.collectibles.length).toEqual(1);
 		func.restore();
 	});
 
-	it('should request collectible custom data if address in contract metadata', async () => {
-		expect(
-			await assetsController.requestNFTCustomInformation('0x06012c8cf97BEaD5deAe237070F9587f8E7A266d', 740632)
-		).not.toEqual({
+	it('should request collectible default data and handle on adding collectible', async () => {
+		await assetsController.addCollectible('0x06012c8cf97BEaD5deAe237070F9587f8E7A266d', 740632);
+		expect(assetsController.state.collectibles[0]).not.toEqual({
+			address: '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d',
 			image: '',
-			name: ''
+			name: '',
+			tokenId: 740632
 		});
-	});
-
-	it('should request collectible default data if address not in contract metadata', async () => {
-		const { name, image } = await assetsController.requestNFTCustomInformation('foo', 1);
-		expect({ name, image }).toEqual({
+		await assetsController.addCollectible('foo', 1);
+		expect(assetsController.state.collectibles[1]).toEqual({
+			address: '0xfoO',
 			image: '',
-			name: ''
+			name: '',
+			tokenId: 1
 		});
 	});
 
@@ -269,7 +272,7 @@ describe('AssetsController', () => {
 	});
 
 	it('should return correct assets state', async () => {
-		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		stub(assetsController, 'requestNFTCustomInformation' as any).returns({ name: 'name', image: 'url' });
 		await assetsController.addCollectible('foo', 1234);
 		assetsController.addToken('foo', 'bar', 2);
 		expect(assetsController.state.tokens).toEqual(TOKENS);

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -15,19 +15,19 @@ describe('AssetsController', () => {
 	it('should set default state', () => {
 		expect(assetsController.state).toEqual({
 			collectibles: [],
-			tokens: []
+			tokens: { '': [] }
 		});
 	});
 
 	it('should add token', () => {
 		assetsController.addToken('foo', 'bar', 2);
-		expect(assetsController.state.tokens[0]).toEqual({
+		expect(assetsController.tokens[0]).toEqual({
 			address: '0xfoO',
 			decimals: 2,
 			symbol: 'bar'
 		});
 		assetsController.addToken('foo', 'baz', 2);
-		expect(assetsController.state.tokens[0]).toEqual({
+		expect(assetsController.tokens[0]).toEqual({
 			address: '0xfoO',
 			decimals: 2,
 			symbol: 'baz'
@@ -37,13 +37,13 @@ describe('AssetsController', () => {
 	it('should remove token', () => {
 		assetsController.addToken('foo', 'bar', 2);
 		assetsController.removeToken('foo');
-		expect(assetsController.state.tokens.length).toBe(0);
+		expect(assetsController.tokens.length).toBe(0);
 	});
 
 	it('should remove collectible', async () => {
 		await assetsController.addCollectible('0xfoO', 1234);
 		assetsController.removeCollectible('0xfoO', 1234);
-		expect(assetsController.state.tokens.length).toBe(0);
+		expect(assetsController.state.collectibles.length).toBe(0);
 	});
 
 	it('should add collectible', async () => {

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -34,10 +34,48 @@ describe('AssetsController', () => {
 		});
 	});
 
+	it('should add token by selected address', () => {
+		const preferences = new PreferencesController();
+		const firstAddress = '0x123';
+		const secondAddress = '0x321';
+		/* tslint:disable-next-line:no-unused-expression */
+		new ComposableController([assetsController, preferences]);
+		preferences.update({ selectedAddress: firstAddress });
+		assetsController.addToken('foo', 'bar', 2);
+		preferences.update({ selectedAddress: secondAddress });
+		expect(assetsController.tokens.length).toEqual(0);
+		preferences.update({ selectedAddress: firstAddress });
+		expect(assetsController.tokens[0]).toEqual({
+			address: '0xfoO',
+			decimals: 2,
+			symbol: 'bar'
+		});
+	});
+
 	it('should remove token', () => {
 		assetsController.addToken('foo', 'bar', 2);
 		assetsController.removeToken('foo');
 		expect(assetsController.tokens.length).toBe(0);
+	});
+
+	it('should remove token by selected address', () => {
+		const preferences = new PreferencesController();
+		const firstAddress = '0x123';
+		const secondAddress = '0x321';
+		/* tslint:disable-next-line:no-unused-expression */
+		new ComposableController([assetsController, preferences]);
+		preferences.update({ selectedAddress: firstAddress });
+		assetsController.addToken('fou', 'baz', 2);
+		preferences.update({ selectedAddress: secondAddress });
+		assetsController.addToken('foo', 'bar', 2);
+		assetsController.removeToken('0xfoO');
+		expect(assetsController.tokens.length).toEqual(0);
+		preferences.update({ selectedAddress: firstAddress });
+		expect(assetsController.tokens[0]).toEqual({
+			address: '0xFOu',
+			decimals: 2,
+			symbol: 'baz'
+		});
 	});
 
 	it('should remove collectible', async () => {

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -14,20 +14,21 @@ describe('AssetsController', () => {
 
 	it('should set default state', () => {
 		expect(assetsController.state).toEqual({
+			allTokens: {},
 			collectibles: [],
-			tokens: { '': [] }
+			tokens: []
 		});
 	});
 
 	it('should add token', () => {
 		assetsController.addToken('foo', 'bar', 2);
-		expect(assetsController.tokens[0]).toEqual({
+		expect(assetsController.state.tokens[0]).toEqual({
 			address: '0xfoO',
 			decimals: 2,
 			symbol: 'bar'
 		});
 		assetsController.addToken('foo', 'baz', 2);
-		expect(assetsController.tokens[0]).toEqual({
+		expect(assetsController.state.tokens[0]).toEqual({
 			address: '0xfoO',
 			decimals: 2,
 			symbol: 'baz'
@@ -43,9 +44,9 @@ describe('AssetsController', () => {
 		preferences.update({ selectedAddress: firstAddress });
 		assetsController.addToken('foo', 'bar', 2);
 		preferences.update({ selectedAddress: secondAddress });
-		expect(assetsController.tokens.length).toEqual(0);
+		expect(assetsController.state.tokens.length).toEqual(0);
 		preferences.update({ selectedAddress: firstAddress });
-		expect(assetsController.tokens[0]).toEqual({
+		expect(assetsController.state.tokens[0]).toEqual({
 			address: '0xfoO',
 			decimals: 2,
 			symbol: 'bar'
@@ -54,8 +55,8 @@ describe('AssetsController', () => {
 
 	it('should remove token', () => {
 		assetsController.addToken('foo', 'bar', 2);
-		assetsController.removeToken('foo');
-		expect(assetsController.tokens.length).toBe(0);
+		assetsController.removeToken('0xfoO');
+		expect(assetsController.state.tokens.length).toBe(0);
 	});
 
 	it('should remove token by selected address', () => {
@@ -69,9 +70,9 @@ describe('AssetsController', () => {
 		preferences.update({ selectedAddress: secondAddress });
 		assetsController.addToken('foo', 'bar', 2);
 		assetsController.removeToken('0xfoO');
-		expect(assetsController.tokens.length).toEqual(0);
+		expect(assetsController.state.tokens.length).toEqual(0);
 		preferences.update({ selectedAddress: firstAddress });
-		expect(assetsController.tokens[0]).toEqual({
+		expect(assetsController.state.tokens[0]).toEqual({
 			address: '0xFOu',
 			decimals: 2,
 			symbol: 'baz'
@@ -132,7 +133,7 @@ describe('AssetsController', () => {
 		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
 		await assetsController.addCollectible('foo', 1234);
 		assetsController.addToken('foo', 'bar', 2);
-		expect(assetsController.tokens).toEqual(TOKENS);
+		expect(assetsController.state.tokens).toEqual(TOKENS);
 		expect(assetsController.collectibles).toEqual(COLLECTIBLES);
 	});
 });

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -1,5 +1,10 @@
 import { stub } from 'sinon';
 import AssetsController from './AssetsController';
+import ComposableController from './ComposableController';
+import PreferencesController from './PreferencesController';
+
+const TOKENS = [{ address: '0xfoO', symbol: 'bar', decimals: 2 }];
+const COLLECTIBLES = [{ address: '0xfoO', image: 'url', name: 'name', tokenId: 1234 }];
 
 describe('AssetsController', () => {
 	let assetsController: AssetsController;
@@ -75,5 +80,21 @@ describe('AssetsController', () => {
 			image: '',
 			name: ''
 		});
+	});
+
+	it('should subscribe to new sibling preference controllers', async () => {
+		const preferences = new PreferencesController();
+		/* tslint:disable-next-line:no-unused-expression */
+		new ComposableController([assetsController, preferences]);
+		preferences.setFeatureFlag('foo', true);
+		expect(assetsController.context.PreferencesController.state.featureFlags.foo).toBe(true);
+	});
+
+	it('should return correct assets state', async () => {
+		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		await assetsController.addCollectible('foo', 1234);
+		assetsController.addToken('foo', 'bar', 2);
+		expect(assetsController.tokens).toEqual(TOKENS);
+		expect(assetsController.collectibles).toEqual(COLLECTIBLES);
 	});
 });

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -1,3 +1,4 @@
+import { stub } from 'sinon';
 import AssetsController from './AssetsController';
 
 describe('PreferencesController', () => {
@@ -32,5 +33,47 @@ describe('PreferencesController', () => {
 		assetsController.addToken('foo', 'bar', 2);
 		assetsController.removeToken('foo');
 		expect(assetsController.state.tokens.length).toBe(0);
+	});
+
+	it('should remove collectible', async () => {
+		await assetsController.addCollectible('0xfoO', 1234);
+		assetsController.removeCollectible('0xfoO', 1234);
+		expect(assetsController.state.tokens.length).toBe(0);
+	});
+
+	it('should add collectible', async () => {
+		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		await assetsController.addCollectible('foo', 1234);
+		expect(assetsController.state.collectibles[0]).toEqual({
+			address: '0xfoO',
+			image: 'url',
+			name: 'name',
+			tokenId: 1234
+		});
+	});
+
+	it('should not add duplicated collectible', async () => {
+		const func = stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		await assetsController.addCollectible('foo', 1234);
+		await assetsController.addCollectible('foo', 1234);
+		expect(assetsController.state.collectibles.length).toEqual(1);
+		func.restore();
+	});
+
+	it('should request collectible custom data if address in contract metadata', async () => {
+		expect(
+			await assetsController.requestNFTCustomInformation('0x06012c8cf97BEaD5deAe237070F9587f8E7A266d', 740632)
+		).not.toEqual({
+			image: '',
+			name: ''
+		});
+	});
+
+	it('should request collectible default data if address not in contract metadata', async () => {
+		const { name, image } = await assetsController.requestNFTCustomInformation('foo', 1);
+		expect({ name, image }).toEqual({
+			image: '',
+			name: ''
+		});
 	});
 });

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -2,6 +2,7 @@ import { stub } from 'sinon';
 import AssetsController from './AssetsController';
 import ComposableController from './ComposableController';
 import PreferencesController from './PreferencesController';
+import { NetworkController } from './NetworkController';
 
 const TOKENS = [{ address: '0xfoO', symbol: 'bar', decimals: 2 }];
 const COLLECTIBLES = [{ address: '0xfoO', image: 'url', name: 'name', tokenId: 1234 }];
@@ -38,15 +39,35 @@ describe('AssetsController', () => {
 
 	it('should add token by selected address', () => {
 		const preferences = new PreferencesController();
+		const network = new NetworkController();
 		const firstAddress = '0x123';
 		const secondAddress = '0x321';
 		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([assetsController, preferences]);
+		new ComposableController([assetsController, network, preferences]);
 		preferences.update({ selectedAddress: firstAddress });
 		assetsController.addToken('foo', 'bar', 2);
 		preferences.update({ selectedAddress: secondAddress });
 		expect(assetsController.state.tokens.length).toEqual(0);
 		preferences.update({ selectedAddress: firstAddress });
+		expect(assetsController.state.tokens[0]).toEqual({
+			address: '0xfoO',
+			decimals: 2,
+			symbol: 'bar'
+		});
+	});
+
+	it('should add token by provider type', () => {
+		const preferences = new PreferencesController();
+		const network = new NetworkController();
+		const firstNetworkType = 'rinkeby';
+		const secondNetworkType = 'ropsten';
+		/* tslint:disable-next-line:no-unused-expression */
+		new ComposableController([assetsController, network, preferences]);
+		network.update({ provider: { type: firstNetworkType } });
+		assetsController.addToken('foo', 'bar', 2);
+		network.update({ provider: { type: secondNetworkType } });
+		expect(assetsController.state.tokens.length).toEqual(0);
+		network.update({ provider: { type: firstNetworkType } });
 		expect(assetsController.state.tokens[0]).toEqual({
 			address: '0xfoO',
 			decimals: 2,
@@ -62,10 +83,11 @@ describe('AssetsController', () => {
 
 	it('should remove token by selected address', () => {
 		const preferences = new PreferencesController();
+		const network = new NetworkController();
 		const firstAddress = '0x123';
 		const secondAddress = '0x321';
 		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([assetsController, preferences]);
+		new ComposableController([assetsController, network, preferences]);
 		preferences.update({ selectedAddress: firstAddress });
 		assetsController.addToken('fou', 'baz', 2);
 		preferences.update({ selectedAddress: secondAddress });
@@ -73,6 +95,27 @@ describe('AssetsController', () => {
 		assetsController.removeToken('0xfoO');
 		expect(assetsController.state.tokens.length).toEqual(0);
 		preferences.update({ selectedAddress: firstAddress });
+		expect(assetsController.state.tokens[0]).toEqual({
+			address: '0xFOu',
+			decimals: 2,
+			symbol: 'baz'
+		});
+	});
+
+	it('should remove token by provider type', () => {
+		const preferences = new PreferencesController();
+		const network = new NetworkController();
+		const firstNetworkType = 'rinkeby';
+		const secondNetworkType = 'ropsten';
+		/* tslint:disable-next-line:no-unused-expression */
+		new ComposableController([assetsController, network, preferences]);
+		network.update({ provider: { type: firstNetworkType } });
+		assetsController.addToken('fou', 'baz', 2);
+		network.update({ provider: { type: secondNetworkType } });
+		assetsController.addToken('foo', 'bar', 2);
+		assetsController.removeToken('0xfoO');
+		expect(assetsController.state.tokens.length).toEqual(0);
+		network.update({ provider: { type: firstNetworkType } });
 		expect(assetsController.state.tokens[0]).toEqual({
 			address: '0xFOu',
 			decimals: 2,
@@ -93,16 +136,38 @@ describe('AssetsController', () => {
 
 	it('should add collectible by selected address', async () => {
 		const preferences = new PreferencesController();
+		const network = new NetworkController();
 		const firstAddress = '0x123';
 		const secondAddress = '0x321';
 		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
 		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([assetsController, preferences]);
+		new ComposableController([assetsController, network, preferences]);
 		preferences.update({ selectedAddress: firstAddress });
 		await assetsController.addCollectible('foo', 1234);
 		preferences.update({ selectedAddress: secondAddress });
-		expect(assetsController.state.collectibles.length).toEqual(0);
+		await assetsController.addCollectible('fou', 4321);
 		preferences.update({ selectedAddress: firstAddress });
+		expect(assetsController.state.collectibles[0]).toEqual({
+			address: '0xfoO',
+			image: 'url',
+			name: 'name',
+			tokenId: 1234
+		});
+	});
+
+	it('should add collectible by provider type', async () => {
+		const preferences = new PreferencesController();
+		const network = new NetworkController();
+		const firstNetworkType = 'rinkeby';
+		const secondNetworkType = 'ropsten';
+		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		/* tslint:disable-next-line:no-unused-expression */
+		new ComposableController([assetsController, network, preferences]);
+		network.update({ provider: { type: firstNetworkType } });
+		await assetsController.addCollectible('foo', 1234);
+		network.update({ provider: { type: secondNetworkType } });
+		expect(assetsController.state.collectibles.length).toEqual(0);
+		network.update({ provider: { type: firstNetworkType } });
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0xfoO',
 			image: 'url',
@@ -120,23 +185,43 @@ describe('AssetsController', () => {
 
 	it('should remove collectible by selected address', async () => {
 		const preferences = new PreferencesController();
+		const network = new NetworkController();
 		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
 		const firstAddress = '0x123';
 		const secondAddress = '0x321';
 		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([assetsController, preferences]);
+		new ComposableController([assetsController, network, preferences]);
 		preferences.update({ selectedAddress: firstAddress });
-
 		await assetsController.addCollectible('fou', 4321);
-
 		preferences.update({ selectedAddress: secondAddress });
-
 		await assetsController.addCollectible('foo', 1234);
-
 		assetsController.removeCollectible('0xfoO', 1234);
-
 		expect(assetsController.state.collectibles.length).toEqual(0);
 		preferences.update({ selectedAddress: firstAddress });
+		expect(assetsController.state.collectibles[0]).toEqual({
+			address: '0xFOu',
+			image: 'url',
+			name: 'name',
+			tokenId: 4321
+		});
+	});
+
+	it('should remove collectible by provider type', async () => {
+		const preferences = new PreferencesController();
+		const network = new NetworkController();
+		stub(assetsController, 'requestNFTCustomInformation').returns({ name: 'name', image: 'url' });
+		const firstNetworkType = 'rinkeby';
+		const secondNetworkType = 'ropsten';
+		/* tslint:disable-next-line:no-unused-expression */
+		new ComposableController([assetsController, network, preferences]);
+		network.update({ provider: { type: firstNetworkType } });
+		await assetsController.addCollectible('fou', 4321);
+		network.update({ provider: { type: secondNetworkType } });
+		await assetsController.addCollectible('foo', 1234);
+		assetsController.removeToken('0xfoO');
+		assetsController.removeCollectible('0xfoO', 1234);
+		expect(assetsController.state.collectibles.length).toEqual(0);
+		network.update({ provider: { type: firstNetworkType } });
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0xFOu',
 			image: 'url',
@@ -172,10 +257,15 @@ describe('AssetsController', () => {
 
 	it('should subscribe to new sibling preference controllers', async () => {
 		const preferences = new PreferencesController();
+		const network = new NetworkController();
+		const networkType = 'rinkeby';
+		const address = '0x123';
 		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([assetsController, preferences]);
-		preferences.setFeatureFlag('foo', true);
-		expect(assetsController.context.PreferencesController.state.featureFlags.foo).toBe(true);
+		new ComposableController([assetsController, network, preferences]);
+		preferences.update({ selectedAddress: address });
+		expect(assetsController.context.PreferencesController.state.selectedAddress).toEqual(address);
+		network.update({ provider: { type: networkType } });
+		expect(assetsController.context.NetworkController.state.provider.type).toEqual(networkType);
 	});
 
 	it('should return correct assets state', async () => {

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -232,7 +232,9 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	 */
 	get tokens(): Token[] {
 		const selectedAddress = this.config.selectedAddress;
-		return this.state.tokens[selectedAddress];
+		const tokens = this.state.tokens;
+		const addressTokens = tokens[selectedAddress] || [];
+		return addressTokens;
 	}
 
 	/**

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -121,8 +121,9 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			tokens.push(newEntry);
 		}
 
-		const newTokens = { ...allTokens, ...{ [selectedAddress]: tokens } };
-		this.update({ allTokens: newTokens });
+		const newAllTokens = { ...allTokens, ...{ [selectedAddress]: tokens } };
+		const newTokens = [...tokens];
+		this.update({ allTokens: newAllTokens, tokens: newTokens });
 		return newTokens;
 	}
 

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -1,0 +1,112 @@
+import BaseController, { BaseConfig, BaseState } from './BaseController';
+import { Token } from './TokenRatesController';
+
+const { toChecksumAddress } = require('ethereumjs-util');
+
+/**
+ * @type Collectible
+ *
+ * Collectible representation
+ *
+ * @property address - Hex address of a ERC721 contract
+ * @property tokenId - The NFT identifier
+ * @property name - Name associated with this tokenId and contract address
+ * @property image - URI of custom NFT image associated with this tokenId
+ */
+export interface Collectible {
+	address: string;
+	tokenId: number;
+	name: string;
+	image: string;
+}
+
+/**
+ * @type CollectibleCustomInformation
+ *
+ * Collectible custom information
+ *
+ * @property name - Collectible custom name
+ * @property image - Image custom image URI
+ */
+export interface CollectibleCustomInformation extends BaseState {
+	name: string;
+	image: string;
+}
+
+/**
+ * @type AssetsState
+ *
+ * Assets controller state
+ *
+ * @property collectibles - List of collectibles associated with the active vault
+ * @property tokens - List of tokens associated with the active vault
+ */
+export interface AssetsState extends BaseState {
+	collectibles: Collectible[];
+	tokens: Token[];
+}
+
+/**
+ * Controller that stores assets and exposes convenience methods
+ */
+export class AssetsController extends BaseController<BaseConfig, AssetsState> {
+	/**
+	 * Name of this controller used during composition
+	 */
+	name = 'AssetsController';
+
+	/**
+	 * Creates a AssetsController instance
+	 *
+	 * @param config - Initial options used to configure this controller
+	 * @param state - Initial state to set on this controller
+	 */
+	constructor(config?: Partial<BaseConfig>, state?: Partial<AssetsState>) {
+		super(config, state);
+		this.defaultState = {
+			collectibles: [],
+			tokens: []
+		};
+		this.initialize();
+	}
+
+	/**
+	 * Adds a token to the stored token list
+	 *
+	 * @param address - Hex address of the token contract
+	 * @param symbol - Symbol of the token
+	 * @param decimals - Number of decimals the token uses
+	 * @returns - Current token list
+	 */
+	addToken(address: string, symbol: string, decimals: number) {
+		address = toChecksumAddress(address);
+		const newEntry: Token = { address, symbol, decimals };
+		const tokens = this.state.tokens;
+		const previousEntry = tokens.find((token) => token.address === address);
+
+		if (previousEntry) {
+			const previousIndex = tokens.indexOf(previousEntry);
+			tokens[previousIndex] = newEntry;
+		} else {
+			tokens.push(newEntry);
+		}
+
+		const newTokens = [...tokens];
+		this.update({ tokens: newTokens });
+		return newTokens;
+	}
+
+	/**
+	 * Removes a token from the stored token list
+	 *
+	 * @param address - Hex address of the token contract
+	 */
+	removeToken(address: string) {
+		address = toChecksumAddress(address);
+		const oldTokens = this.state.tokens;
+		const tokens = oldTokens.filter((token) => token.address !== address);
+		this.update({ tokens });
+	}
+}
+
+export default AssetsController;

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -2,6 +2,7 @@ import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from './BaseController';
 import PreferencesController from './PreferencesController';
 import { Token } from './TokenRatesController';
+import { NetworkController } from './NetworkController';
 
 const contractMap = require('eth-contract-metadata');
 const { toChecksumAddress } = require('ethereumjs-util');
@@ -41,9 +42,11 @@ export interface CollectibleCustomInformation {
  *
  * Assets controller configuration
  *
+ * @property networkType - Network ID as per net_version
  * @property selectedAddress - Vault selected address
  */
 export interface AssetsConfig extends BaseConfig {
+	networkType: string;
 	selectedAddress: string;
 }
 
@@ -56,8 +59,8 @@ export interface AssetsConfig extends BaseConfig {
  * @property tokens - List of tokens associated with the active vault
  */
 export interface AssetsState extends BaseState {
-	allTokens: { [key: string]: Token[] };
-	allCollectibles: { [key: string]: Collectible[] };
+	allTokens: { [key: string]: { [key: string]: Token[] } };
+	allCollectibles: { [key: string]: { [key: string]: Collectible[] } };
 	collectibles: Collectible[];
 	tokens: Token[];
 }
@@ -78,7 +81,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	/**
 	 * List of required sibling controllers this controller needs to function
 	 */
-	requiredControllers = ['PreferencesController'];
+	requiredControllers = ['NetworkController', 'PreferencesController'];
 
 	/**
 	 * Creates a AssetsController instance
@@ -89,6 +92,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	constructor(config?: Partial<BaseConfig>, state?: Partial<AssetsState>) {
 		super(config, state);
 		this.defaultConfig = {
+			networkType: '',
 			selectedAddress: ''
 		};
 		this.defaultState = {
@@ -113,17 +117,18 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		const tokens = this.state.tokens;
 		const allTokens = this.state.allTokens;
 		const selectedAddress = this.config.selectedAddress;
+		const networkType = this.config.networkType;
 		const newEntry: Token = { address, symbol, decimals };
 		const previousEntry = tokens.find((token) => token.address === address);
-
 		if (previousEntry) {
 			const previousIndex = tokens.indexOf(previousEntry);
 			tokens[previousIndex] = newEntry;
 		} else {
 			tokens.push(newEntry);
 		}
-
-		const newAllTokens = { ...allTokens, ...{ [selectedAddress]: tokens } };
+		const addressTokens = allTokens[selectedAddress];
+		const newAddressTokens = { ...addressTokens, ...{ [networkType]: tokens } };
+		const newAllTokens = { ...allTokens, ...{ [selectedAddress]: newAddressTokens } };
 		const newTokens = [...tokens];
 		this.update({ allTokens: newAllTokens, tokens: newTokens });
 		return newTokens;
@@ -141,20 +146,39 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		const collectibles = this.state.collectibles;
 		const allCollectibles = this.state.allCollectibles;
 		const selectedAddress = this.config.selectedAddress;
-		const existingEntry = this.state.collectibles.find(
+		const networkType = this.config.networkType;
+		const existingEntry = collectibles.find(
 			(collectible) => collectible.address === address && collectible.tokenId === tokenId
 		);
-
 		if (existingEntry) {
 			return collectibles;
 		}
 		const { name, image } = await this.requestNFTCustomInformation(address, tokenId);
 		const newEntry: Collectible = { address, tokenId, name, image };
-
 		const newCollectibles = [...collectibles, newEntry];
-		const newAllCollectibles = { ...allCollectibles, [selectedAddress]: newCollectibles };
+		const addressCollectibles = allCollectibles[selectedAddress];
+		const newAddressCollectibles = { ...addressCollectibles, ...{ [networkType]: newCollectibles } };
+		const newAllCollectibles = { ...allCollectibles, ...{ [selectedAddress]: newAddressCollectibles } };
 		this.update({ allCollectibles: newAllCollectibles, collectibles: newCollectibles });
 		return newCollectibles;
+	}
+
+	/**
+	 * Removes a token from the stored token list
+	 *
+	 * @param address - Hex address of the token contract
+	 */
+	removeToken(address: string) {
+		address = toChecksumAddress(address);
+		const oldTokens = this.state.tokens;
+		const allTokens = this.state.allTokens;
+		const selectedAddress = this.config.selectedAddress;
+		const networkType = this.config.networkType;
+		const newTokens = oldTokens.filter((token) => token.address !== address);
+		const addressTokens = allTokens[selectedAddress];
+		const newAddressTokens = { ...addressTokens, ...{ [networkType]: newTokens } };
+		const newAllTokens = { ...allTokens, ...{ [selectedAddress]: newAddressTokens } };
+		this.update({ allTokens: newAllTokens, tokens: newTokens });
 	}
 
 	/**
@@ -168,29 +192,14 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		const oldCollectibles = this.state.collectibles;
 		const allCollectibles = this.state.allCollectibles;
 		const selectedAddress = this.config.selectedAddress;
-
+		const networkType = this.config.networkType;
 		const newCollectibles = oldCollectibles.filter(
 			(collectible) => !(collectible.address === address && collectible.tokenId === tokenId)
 		);
-
-		const newAllCollectibles = { ...allCollectibles, [selectedAddress]: newCollectibles };
+		const addressCollectibles = allCollectibles[selectedAddress];
+		const newAddressCollectibles = { ...addressCollectibles, ...{ [networkType]: newCollectibles } };
+		const newAllCollectibles = { ...allCollectibles, ...{ [selectedAddress]: newAddressCollectibles } };
 		this.update({ allCollectibles: newAllCollectibles, collectibles: newCollectibles });
-	}
-
-	/**
-	 * Removes a token from the stored token list
-	 *
-	 * @param address - Hex address of the token contract
-	 */
-	removeToken(address: string) {
-		address = toChecksumAddress(address);
-		const oldTokens = this.state.tokens;
-		const allTokens = this.state.allTokens;
-		const selectedAddress = this.config.selectedAddress;
-
-		const newTokens = oldTokens.filter((token) => token.address !== address);
-		const newAllTokens = { ...allTokens, ...{ [selectedAddress]: newTokens } };
-		this.update({ allTokens: newAllTokens, tokens: newTokens });
 	}
 
 	/**
@@ -236,13 +245,26 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	onComposed() {
 		super.onComposed();
 		const preferences = this.context.PreferencesController as PreferencesController;
+		const network = this.context.NetworkController as NetworkController;
 		preferences.subscribe(({ selectedAddress }) => {
 			const allTokens = this.state.allTokens;
 			const allCollectibles = this.state.allCollectibles;
+			const networkType = this.config.networkType;
 			this.configure({ selectedAddress });
 			this.update({
-				collectibles: allCollectibles[selectedAddress] || [],
-				tokens: allTokens[selectedAddress] || []
+				collectibles: (allCollectibles[selectedAddress] && allCollectibles[selectedAddress][networkType]) || [],
+				tokens: (allTokens[selectedAddress] && allTokens[selectedAddress][networkType]) || []
+			});
+		});
+		network.subscribe(({ provider }) => {
+			const allTokens = this.state.allTokens;
+			const allCollectibles = this.state.allCollectibles;
+			const selectedAddress = this.config.selectedAddress;
+			const networkType = provider.type;
+			this.configure({ networkType });
+			this.update({
+				collectibles: (allCollectibles[selectedAddress] && allCollectibles[selectedAddress][networkType]) || [],
+				tokens: (allTokens[selectedAddress] && allTokens[selectedAddress][networkType]) || []
 			});
 		});
 	}

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -1,8 +1,8 @@
 import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from './BaseController';
 import PreferencesController from './PreferencesController';
+import NetworkController from './NetworkController';
 import { Token } from './TokenRatesController';
-import { NetworkController } from './NetworkController';
 
 const contractMap = require('eth-contract-metadata');
 const { toChecksumAddress } = require('ethereumjs-util');
@@ -55,6 +55,8 @@ export interface AssetsConfig extends BaseConfig {
  *
  * Assets controller state
  *
+ * @property allTokens - Object containing tokens per account and network
+ * @property allCollectibles - Object containing collectibles per account and network
  * @property collectibles - List of collectibles associated with the active vault
  * @property tokens - List of tokens associated with the active vault
  */

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -17,8 +17,7 @@ describe('ComposableController', () => {
 				featureFlags: {},
 				identities: {},
 				lostIdentities: {},
-				selectedAddress: '',
-				tokens: []
+				selectedAddress: ''
 			},
 			TokenRatesController: { contractExchangeRates: {} }
 		});
@@ -36,8 +35,7 @@ describe('ComposableController', () => {
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
-			selectedAddress: '',
-			tokens: []
+			selectedAddress: ''
 		});
 	});
 
@@ -57,8 +55,7 @@ describe('ComposableController', () => {
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
-			selectedAddress: '',
-			tokens: []
+			selectedAddress: ''
 		});
 	});
 

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -15,7 +15,7 @@ describe('ComposableController', () => {
 		]);
 		expect(controller.state).toEqual({
 			AddressBookController: { addressBook: [] },
-			AssetsController: { allTokens: {}, collectibles: [], tokens: [] },
+			AssetsController: { allTokens: {}, allCollectibles: {}, collectibles: [], tokens: [] },
 			PreferencesController: {
 				featureFlags: {},
 				identities: {},
@@ -35,6 +35,7 @@ describe('ComposableController', () => {
 		]);
 		expect(controller.flatState).toEqual({
 			addressBook: [],
+			allCollectibles: {},
 			allTokens: {},
 			collectibles: [],
 			contractExchangeRates: {},
@@ -59,6 +60,7 @@ describe('ComposableController', () => {
 		addressContext.set('1337', 'foo');
 		expect(controller.flatState).toEqual({
 			addressBook: [{ address: '1337', name: 'foo' }],
+			allCollectibles: {},
 			allTokens: {},
 			collectibles: [],
 			contractExchangeRates: {},

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -4,18 +4,24 @@ import ComposableController from './ComposableController';
 import PreferencesController from './PreferencesController';
 import TokenRatesController from './TokenRatesController';
 import { AssetsController } from './AssetsController';
+import { NetworkController } from './NetworkController';
 
 describe('ComposableController', () => {
 	it('should compose controller state', () => {
 		const controller = new ComposableController([
 			new AddressBookController(),
 			new AssetsController(),
+			new NetworkController(),
 			new PreferencesController(),
 			new TokenRatesController()
 		]);
 		expect(controller.state).toEqual({
 			AddressBookController: { addressBook: [] },
 			AssetsController: { allTokens: {}, allCollectibles: {}, collectibles: [], tokens: [] },
+			NetworkController: {
+				network: 'loading',
+				provider: { type: 'rinkeby' }
+			},
 			PreferencesController: {
 				featureFlags: {},
 				identities: {},
@@ -30,6 +36,7 @@ describe('ComposableController', () => {
 		const controller = new ComposableController([
 			new AddressBookController(),
 			new AssetsController(),
+			new NetworkController(),
 			new PreferencesController(),
 			new TokenRatesController()
 		]);
@@ -42,6 +49,8 @@ describe('ComposableController', () => {
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
+			network: 'loading',
+			provider: { type: 'rinkeby' },
 			selectedAddress: '',
 			tokens: []
 		});
@@ -51,6 +60,7 @@ describe('ComposableController', () => {
 		const controller = new ComposableController([
 			new AddressBookController(),
 			new AssetsController(),
+			new NetworkController(),
 			new PreferencesController(),
 			new TokenRatesController()
 		]);
@@ -67,6 +77,8 @@ describe('ComposableController', () => {
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
+			network: 'loading',
+			provider: { type: 'rinkeby' },
 			selectedAddress: '',
 			tokens: []
 		});

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -3,16 +3,19 @@ import AddressBookController from './AddressBookController';
 import ComposableController from './ComposableController';
 import PreferencesController from './PreferencesController';
 import TokenRatesController from './TokenRatesController';
+import { AssetsController } from './AssetsController';
 
 describe('ComposableController', () => {
 	it('should compose controller state', () => {
 		const controller = new ComposableController([
 			new AddressBookController(),
+			new AssetsController(),
 			new PreferencesController(),
 			new TokenRatesController()
 		]);
 		expect(controller.state).toEqual({
 			AddressBookController: { addressBook: [] },
+			AssetsController: { collectibles: [], tokens: [] },
 			PreferencesController: {
 				featureFlags: {},
 				identities: {},
@@ -26,22 +29,26 @@ describe('ComposableController', () => {
 	it('should compose flat controller state', () => {
 		const controller = new ComposableController([
 			new AddressBookController(),
+			new AssetsController(),
 			new PreferencesController(),
 			new TokenRatesController()
 		]);
 		expect(controller.flatState).toEqual({
 			addressBook: [],
+			collectibles: [],
 			contractExchangeRates: {},
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
-			selectedAddress: ''
+			selectedAddress: '',
+			tokens: []
 		});
 	});
 
 	it('should expose sibling context', () => {
 		const controller = new ComposableController([
 			new AddressBookController(),
+			new AssetsController(),
 			new PreferencesController(),
 			new TokenRatesController()
 		]);
@@ -51,11 +58,13 @@ describe('ComposableController', () => {
 		addressContext.set('1337', 'foo');
 		expect(controller.flatState).toEqual({
 			addressBook: [{ address: '1337', name: 'foo' }],
+			collectibles: [],
 			contractExchangeRates: {},
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
-			selectedAddress: ''
+			selectedAddress: '',
+			tokens: []
 		});
 	});
 

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -15,7 +15,7 @@ describe('ComposableController', () => {
 		]);
 		expect(controller.state).toEqual({
 			AddressBookController: { addressBook: [] },
-			AssetsController: { collectibles: [], tokens: [] },
+			AssetsController: { collectibles: [], tokens: { '': [] } },
 			PreferencesController: {
 				featureFlags: {},
 				identities: {},
@@ -41,7 +41,7 @@ describe('ComposableController', () => {
 			identities: {},
 			lostIdentities: {},
 			selectedAddress: '',
-			tokens: []
+			tokens: { '': [] }
 		});
 	});
 
@@ -64,7 +64,7 @@ describe('ComposableController', () => {
 			identities: {},
 			lostIdentities: {},
 			selectedAddress: '',
-			tokens: []
+			tokens: { '': [] }
 		});
 	});
 

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -15,7 +15,7 @@ describe('ComposableController', () => {
 		]);
 		expect(controller.state).toEqual({
 			AddressBookController: { addressBook: [] },
-			AssetsController: { collectibles: [], tokens: { '': [] } },
+			AssetsController: { allTokens: {}, collectibles: [], tokens: [] },
 			PreferencesController: {
 				featureFlags: {},
 				identities: {},
@@ -35,13 +35,14 @@ describe('ComposableController', () => {
 		]);
 		expect(controller.flatState).toEqual({
 			addressBook: [],
+			allTokens: {},
 			collectibles: [],
 			contractExchangeRates: {},
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
 			selectedAddress: '',
-			tokens: { '': [] }
+			tokens: []
 		});
 	});
 
@@ -58,13 +59,14 @@ describe('ComposableController', () => {
 		addressContext.set('1337', 'foo');
 		expect(controller.flatState).toEqual({
 			addressBook: [{ address: '1337', name: 'foo' }],
+			allTokens: {},
 			collectibles: [],
 			contractExchangeRates: {},
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
 			selectedAddress: '',
-			tokens: { '': [] }
+			tokens: []
 		});
 	});
 

--- a/src/PreferencesController.test.ts
+++ b/src/PreferencesController.test.ts
@@ -7,8 +7,7 @@ describe('PreferencesController', () => {
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
-			selectedAddress: '',
-			tokens: []
+			selectedAddress: ''
 		});
 	});
 
@@ -24,22 +23,6 @@ describe('PreferencesController', () => {
 		});
 	});
 
-	it('should add token', () => {
-		const controller = new PreferencesController();
-		controller.addToken('foo', 'bar', 2);
-		expect(controller.state.tokens[0]).toEqual({
-			address: '0xfoO',
-			decimals: 2,
-			symbol: 'bar'
-		});
-		controller.addToken('foo', 'baz', 2);
-		expect(controller.state.tokens[0]).toEqual({
-			address: '0xfoO',
-			decimals: 2,
-			symbol: 'baz'
-		});
-	});
-
 	it('should remove identity', () => {
 		const controller = new PreferencesController();
 		controller.addIdentities(['foo', 'bar', 'baz']);
@@ -49,13 +32,6 @@ describe('PreferencesController', () => {
 		controller.removeIdentity('foo');
 		expect(typeof controller.state.identities['0xfoO']).toBe('undefined');
 		expect(controller.state.selectedAddress).toBe('0xbar');
-	});
-
-	it('should remove token', () => {
-		const controller = new PreferencesController();
-		controller.addToken('foo', 'bar', 2);
-		controller.removeToken('foo');
-		expect(controller.state.tokens.length).toBe(0);
 	});
 
 	it('should set identity label', () => {

--- a/src/PreferencesController.ts
+++ b/src/PreferencesController.ts
@@ -1,6 +1,5 @@
 import BaseController, { BaseConfig, BaseState } from './BaseController';
 import { ContactEntry } from './AddressBookController';
-import { Token } from './TokenRatesController';
 
 const { toChecksumAddress } = require('ethereumjs-util');
 
@@ -13,14 +12,12 @@ const { toChecksumAddress } = require('ethereumjs-util');
  * @property identities - Map of addresses to ContactEntry objects
  * @property lostIdentities - Map of lost addresses to ContactEntry objects
  * @property selectedAddress - Current coinbase account
- * @property tokens - List of tokens associated with the active vault
  */
 export interface PreferencesState extends BaseState {
 	featureFlags: { [feature: string]: boolean };
 	identities: { [address: string]: ContactEntry };
 	lostIdentities: { [address: string]: ContactEntry };
 	selectedAddress: string;
-	tokens: Token[];
 }
 
 /**
@@ -44,8 +41,7 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 			featureFlags: {},
 			identities: {},
 			lostIdentities: {},
-			selectedAddress: '',
-			tokens: []
+			selectedAddress: ''
 		};
 		this.initialize();
 	}
@@ -69,32 +65,6 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	}
 
 	/**
-	 * Adds a token to the stored token list
-	 *
-	 * @param address - Hex address of the token contract
-	 * @param symbol - Symbol of the token
-	 * @param decimals - Number of decimals the token uses
-	 * @returns - Current token list
-	 */
-	addToken(address: string, symbol: string, decimals: number) {
-		address = toChecksumAddress(address);
-		const newEntry: Token = { address, symbol, decimals };
-		const tokens = this.state.tokens;
-		const previousEntry = tokens.find((token) => token.address === address);
-
-		if (previousEntry) {
-			const previousIndex = tokens.indexOf(previousEntry);
-			tokens[previousIndex] = newEntry;
-		} else {
-			tokens.push(newEntry);
-		}
-
-		const newTokens = [...tokens];
-		this.update({ tokens: newTokens });
-		return newTokens;
-	}
-
-	/**
 	 * Removes an identity from state
 	 *
 	 * @param address - Address of the identity to remove
@@ -110,18 +80,6 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 		if (address === this.state.selectedAddress) {
 			this.update({ selectedAddress: Object.keys(identities)[0] });
 		}
-	}
-
-	/**
-	 * Removes a token from the stored token list
-	 *
-	 * @param address - Hex address of the token contract
-	 */
-	removeToken(address: string) {
-		address = toChecksumAddress(address);
-		const oldTokens = this.state.tokens;
-		const tokens = oldTokens.filter((token) => token.address !== address);
-		this.update({ tokens });
 	}
 
 	/**

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -3,6 +3,7 @@ import ComposableController from './ComposableController';
 import TokenRatesController, { Token } from './TokenRatesController';
 import { AssetsController } from './AssetsController';
 import { PreferencesController } from './PreferencesController';
+import { NetworkController } from './NetworkController';
 
 describe('TokenRatesController', () => {
 	it('should set default state', () => {
@@ -72,9 +73,10 @@ describe('TokenRatesController', () => {
 	it('should subscribe to new sibling assets controllers', async () => {
 		const assets = new AssetsController();
 		const controller = new TokenRatesController();
+		const network = new NetworkController();
 		const preferences = new PreferencesController();
 		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([controller, assets, preferences]);
+		new ComposableController([controller, assets, network, preferences]);
 		assets.addToken('0xfoO', 'FOO', 18);
 		const tokens = controller.context.AssetsController.state.tokens;
 		const found = tokens.filter((token: Token) => token.address === '0xfoO');

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -2,6 +2,7 @@ import { stub } from 'sinon';
 import ComposableController from './ComposableController';
 import TokenRatesController, { Token } from './TokenRatesController';
 import { AssetsController } from './AssetsController';
+import { PreferencesController } from './PreferencesController';
 
 describe('TokenRatesController', () => {
 	it('should set default state', () => {
@@ -71,8 +72,9 @@ describe('TokenRatesController', () => {
 	it('should subscribe to new sibling assets controllers', async () => {
 		const assets = new AssetsController();
 		const controller = new TokenRatesController();
+		const preferences = new PreferencesController();
 		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([controller, assets]);
+		new ComposableController([controller, assets, preferences]);
 		assets.addToken('0xfoO', 'FOO', 18);
 		const tokens = controller.context.AssetsController.state.tokens;
 		const found = tokens.filter((token: Token) => token.address === '0xfoO');

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -1,6 +1,5 @@
 import { stub } from 'sinon';
 import ComposableController from './ComposableController';
-import PreferencesController from './PreferencesController';
 import TokenRatesController, { Token } from './TokenRatesController';
 import { AssetsController } from './AssetsController';
 

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -76,8 +76,7 @@ describe('TokenRatesController', () => {
 		/* tslint:disable-next-line:no-unused-expression */
 		new ComposableController([controller, assets, preferences]);
 		assets.addToken('0xfoO', 'FOO', 18);
-		const selectedAddress = controller.context.AssetsController.config.selectedAddress;
-		const tokens = controller.context.AssetsController.state.tokens[selectedAddress];
+		const tokens = controller.context.AssetsController.state.tokens;
 		const found = tokens.filter((token: Token) => token.address === '0xfoO');
 		expect(found.length > 0).toBe(true);
 	});

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -1,7 +1,8 @@
 import { stub } from 'sinon';
 import ComposableController from './ComposableController';
 import PreferencesController from './PreferencesController';
-import TokenRatesController from './TokenRatesController';
+import TokenRatesController, { Token } from './TokenRatesController';
+import { AssetsController } from './AssetsController';
 
 describe('TokenRatesController', () => {
 	it('should set default state', () => {
@@ -68,12 +69,14 @@ describe('TokenRatesController', () => {
 		func.restore();
 	});
 
-	it('should subscribe to new sibling preference controllers', async () => {
-		const preferences = new PreferencesController();
+	it('should subscribe to new sibling assets controllers', async () => {
+		const assets = new AssetsController();
 		const controller = new TokenRatesController();
 		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([controller, preferences]);
-		preferences.setFeatureFlag('foo', true);
-		expect(controller.context.PreferencesController.state.featureFlags.foo).toBe(true);
+		new ComposableController([controller, assets]);
+		assets.addToken('0xfoO', 'FOO', 18);
+		const tokens = controller.context.AssetsController.state.tokens;
+		const found = tokens.filter((token: Token) => token.address === '0xfoO');
+		expect(found.length > 0).toBe(true);
 	});
 });

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -76,7 +76,8 @@ describe('TokenRatesController', () => {
 		/* tslint:disable-next-line:no-unused-expression */
 		new ComposableController([controller, assets, preferences]);
 		assets.addToken('0xfoO', 'FOO', 18);
-		const tokens = controller.context.AssetsController.state.tokens;
+		const selectedAddress = controller.context.AssetsController.config.selectedAddress;
+		const tokens = controller.context.AssetsController.state.tokens[selectedAddress];
 		const found = tokens.filter((token: Token) => token.address === '0xfoO');
 		expect(found.length > 0).toBe(true);
 	});

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from './BaseController';
-import PreferencesController from './PreferencesController';
+import AssetsController from './AssetsController';
 import { safelyExecute } from './util';
 
 /**
@@ -44,7 +44,7 @@ export interface TokenRatesState extends BaseState {
 
 /**
  * Controller that passively polls on a set interval for token-to-fiat exchange rates
- * for tokens stored in the PreferencesController
+ * for tokens stored in the AssetsController
  */
 export class TokenRatesController extends BaseController<TokenRatesConfig, TokenRatesState> {
 	private handle?: NodeJS.Timer;
@@ -62,7 +62,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	/**
 	 * List of required sibling controllers this controller needs to function
 	 */
-	requiredControllers = ['PreferencesController'];
+	requiredControllers = ['AssetsController'];
 
 	/**
 	 * Creates a TokenRatesController instance
@@ -121,8 +121,8 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	 */
 	onComposed() {
 		super.onComposed();
-		const preferences = this.context.PreferencesController as PreferencesController;
-		preferences.subscribe(({ tokens }) => {
+		const assets = this.context.AssetsController as AssetsController;
+		assets.subscribe(({ tokens }) => {
 			this.configure({ tokens });
 		});
 	}

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -123,7 +123,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 		super.onComposed();
 		const assets = this.context.AssetsController as AssetsController;
 		assets.subscribe(() => {
-			this.configure({ tokens: assets.tokens });
+			this.configure({ tokens: assets.state.tokens });
 		});
 	}
 

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -122,8 +122,8 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	onComposed() {
 		super.onComposed();
 		const assets = this.context.AssetsController as AssetsController;
-		assets.subscribe(({ tokens }) => {
-			this.configure({ tokens });
+		assets.subscribe(() => {
+			this.configure({ tokens: assets.tokens });
 		});
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as util from './util';
 
 export * from './AccountTrackerController';
 export * from './AddressBookController';
+export * from './AssetsController';
 export * from './BaseController';
 export * from './BlockHistoryController';
 export * from './ComposableController';


### PR DESCRIPTION
This PR adds AssetsController in order to support assets on it. First two assets supported are tokens (ERC20) and collectibles (ERC721).

- [x] Add collectible/token
- [x] Remove collectible/token
- [x] Assets per account and network basis
- [x] Tests

Related https://github.com/MetaMask/gaba/pull/17

BLOCKER: eth-contract-metadata is not the official, we should decide what to do with collectibles metadata before merge. 