### PR TITLE
Frequent RPC list

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -24,6 +24,7 @@ describe('ComposableController', () => {
 			},
 			PreferencesController: {
 				featureFlags: {},
+				frequentRpcList: [],
 				identities: {},
 				lostIdentities: {},
 				selectedAddress: ''
@@ -47,6 +48,7 @@ describe('ComposableController', () => {
 			collectibles: [],
 			contractExchangeRates: {},
 			featureFlags: {},
+			frequentRpcList: [],
 			identities: {},
 			lostIdentities: {},
 			network: 'loading',
@@ -75,6 +77,7 @@ describe('ComposableController', () => {
 			collectibles: [],
 			contractExchangeRates: {},
 			featureFlags: {},
+			frequentRpcList: [],
 			identities: {},
 			lostIdentities: {},
 			network: 'loading',

--- a/src/NetworkController.ts
+++ b/src/NetworkController.ts
@@ -197,7 +197,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 		this.update({
 			provider: {
 				...this.state.provider,
-				...{ rpcTarget }
+				...{ type: 'rpc', rpcTarget }
 			}
 		});
 		this.refreshNetwork();

--- a/src/PreferencesController.test.ts
+++ b/src/PreferencesController.test.ts
@@ -5,6 +5,7 @@ describe('PreferencesController', () => {
 		const controller = new PreferencesController();
 		expect(controller.state).toEqual({
 			featureFlags: {},
+			frequentRpcList: [],
 			identities: {},
 			lostIdentities: {},
 			selectedAddress: ''
@@ -65,5 +66,24 @@ describe('PreferencesController', () => {
 			['0xbar']: { address: '0xbar', name: 'Account 2' },
 			['0xfoO']: { address: '0xfoO', name: 'Account 1' }
 		});
+	});
+
+	it('should add custom rpc url', () => {
+		const controller = new PreferencesController();
+		controller.addToFrequentRpcList('rpc_url');
+		controller.addToFrequentRpcList('http://localhost:8545');
+		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
+		controller.addToFrequentRpcList('rpc_url');
+		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
+	});
+
+	it('should remove custom rpc url', () => {
+		const controller = new PreferencesController();
+		controller.addToFrequentRpcList('rpc_url');
+		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
+		controller.removeFromFrequentRpcList('other_rpc_url');
+		controller.removeFromFrequentRpcList('http://localhost:8545');
+		controller.removeFromFrequentRpcList('rpc_url');
+		expect(controller.state.frequentRpcList).toEqual([]);
 	});
 });

--- a/src/PreferencesController.ts
+++ b/src/PreferencesController.ts
@@ -9,12 +9,14 @@ const { toChecksumAddress } = require('ethereumjs-util');
  * Preferences controller state
  *
  * @property featureFlags - Map of specific features to enable or disable
+ * @property frequentRpcList - A list of custom RPCs to provide the user
  * @property identities - Map of addresses to ContactEntry objects
  * @property lostIdentities - Map of lost addresses to ContactEntry objects
  * @property selectedAddress - Current coinbase account
  */
 export interface PreferencesState extends BaseState {
 	featureFlags: { [feature: string]: boolean };
+	frequentRpcList: string[];
 	identities: { [address: string]: ContactEntry };
 	lostIdentities: { [address: string]: ContactEntry };
 	selectedAddress: string;
@@ -39,6 +41,7 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 		super(config, state);
 		this.defaultState = {
 			featureFlags: {},
+			frequentRpcList: [],
 			identities: {},
 			lostIdentities: {},
 			selectedAddress: ''
@@ -159,6 +162,45 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 			return ids;
 		}, {});
 		this.update({ identities });
+	}
+
+	/**
+	 * Adds custom RPC URL to state
+	 *
+	 * @param url - Custom RPC URL
+	 */
+	addToFrequentRpcList(url: string) {
+		if (url === 'http://localhost:8545') {
+			return;
+		}
+		const newFrequentRpcList = this.state.frequentRpcList;
+		const index = newFrequentRpcList.findIndex((element) => {
+			return element === url;
+		});
+		if (index !== -1) {
+			newFrequentRpcList.splice(index, 1);
+		}
+		newFrequentRpcList.push(url);
+		this.update({ frequentRpcList: newFrequentRpcList });
+	}
+
+	/**
+	 * Removes custom RPC URL from state
+	 *
+	 * @param url - Custom RPC URL
+	 */
+	removeFromFrequentRpcList(url: string) {
+		if (url === 'http://localhost:8545') {
+			return;
+		}
+		const newFrequentRpcList = this.state.frequentRpcList;
+		const index = newFrequentRpcList.findIndex((element) => {
+			return element === url;
+		});
+		if (index !== -1) {
+			newFrequentRpcList.splice(index, 1);
+		}
+		this.update({ frequentRpcList: newFrequentRpcList });
 	}
 }
 


### PR DESCRIPTION
This PR adds a list of frequent RPC urls in `PreferencesController`, with the objective of adding custom RPC urls.