### PR TITLE
Update eth-block-tracker dep and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "await-semaphore": "^0.1.3",
-    "eth-block-tracker": "^4.1.0",
+    "eth-block-tracker": "^3.0.1",
     "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#master",
     "eth-json-rpc-infura": "^3.1.2",
     "eth-keyring-controller": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "await-semaphore": "^0.1.3",
-    "eth-block-tracker": "^3.0.1",
+    "eth-block-tracker": "^4.0.3",
     "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#master",
     "eth-json-rpc-infura": "^3.1.2",
     "eth-keyring-controller": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaba",
-  "version": "1.0.0-beta.41",
+  "version": "1.0.0-beta.42",
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "license": "MIT",
   "scripts": {
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "await-semaphore": "^0.1.3",
-    "eth-block-tracker": "git://github.com/metamask/eth-block-tracker.git#3.0.1-subscription-fix",
+    "eth-block-tracker": "^4.1.0",
     "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#master",
     "eth-json-rpc-infura": "^3.1.2",
     "eth-keyring-controller": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "await-semaphore": "^0.1.3",
-    "eth-block-tracker": "^4.0.3",
+    "eth-block-tracker": "^3.0.1",
     "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#master",
     "eth-json-rpc-infura": "^3.1.2",
     "eth-keyring-controller": "^4.0.0",

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -159,6 +159,9 @@ describe('AssetsController', () => {
 	});
 
 	it('should add collectible with tokenURI, metadata and enumerable support', async () => {
+		getOnce('https://api.godsunchained.com/card/1', () => ({
+			body: JSON.stringify({ image: 'https://api.godsunchained.com/v0/image/7', name: 'Broken Harvester' })
+		}));
 		/* tslint:disable-next-line:no-unused-expression */
 		new ComposableController([assetsController, assetsContract, network, preferences]);
 		assetsContract.configure({ provider: MAINNET_PROVIDER });

--- a/src/AssetsDetectionController.test.ts
+++ b/src/AssetsDetectionController.test.ts
@@ -115,6 +115,9 @@ describe('AssetsDetectionController', () => {
 	});
 
 	it('should detect enumerable collectibles correctly', async () => {
+		getOnce('https://api.godsunchained.com/card/0', () => ({
+			body: JSON.stringify({ image: 'https://api.godsunchained.com/v0/image/380', name: 'First Pheonix' })
+		}));
 		assetsDetection.configure({
 			providerType: 'mainnet',
 			selectedAddress: '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d'


### PR DESCRIPTION
The branch we were using (`3.0.1-subscription-fix`) has been deleted and now you can't run npm i gaba