### PR TITLE
Make sure accounts is always an  Array

### DIFF
--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -318,7 +318,7 @@ export class KeyringController extends BaseController<BaseConfig, KeyringState> 
 		const keyrings = await Promise.all(
 			this.keyring.keyrings.map(async (keyring: KeyringObject, index: number) => {
 				const keyringAccounts = await keyring.getAccounts();
-				const accounts = keyringAccounts.length ? keyringAccounts.map((address) => toChecksumAddress(address)) : [];
+				const accounts = Array.isArray(keyringAccounts) ? keyringAccounts.map((address) => toChecksumAddress(address)) : [];
 				return {
 					accounts,
 					index,

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -317,7 +317,7 @@ export class KeyringController extends BaseController<BaseConfig, KeyringState> 
 	async fullUpdate() {
 		const keyrings = await Promise.all(
 			this.keyring.keyrings.map(async (keyring: KeyringObject, index: number) => {
-				const keyringAccounts = yield keyring.getAccounts();
+				const keyringAccounts = await keyring.getAccounts();
 				const accounts = keyringAccounts.length ? keyringAccounts.map((address) => toChecksumAddress(address)) : [];
 				return {
 					accounts,

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -317,8 +317,10 @@ export class KeyringController extends BaseController<BaseConfig, KeyringState> 
 	async fullUpdate() {
 		const keyrings = await Promise.all(
 			this.keyring.keyrings.map(async (keyring: KeyringObject, index: number) => {
+				const keyringAccounts = yield keyring.getAccounts();
+				const accounts = keyringAccounts.length ? keyringAccounts.map((address) => toChecksumAddress(address)) : [];
 				return {
-					accounts: await keyring.getAccounts().map((address) => toChecksumAddress(address)),
+					accounts,
 					index,
 					type: keyring.type
 				};


### PR DESCRIPTION
I was doing `keyring.getAccounts().map` but when you're starting from scratch there's no keyring and undefined.map() breaks.