### PR TITLE
Basic usage gas when transaction to is undefined

### DIFF
--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -310,11 +310,11 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 			return { gas, gasPrice };
 		}
 
-		// 2. If this is not a contract address, use 0x5208 / 21000
+		// 2. If to is not defined or this is not a contract address, use 0x5208 / 21000
 		/* istanbul ignore next */
 		const code = to ? await this.query('getCode', [to]) : undefined;
 		/* istanbul ignore next */
-		if (to && (!code || code === '0x')) {
+		if (!to || (to && (!code || code === '0x'))) {
 			return { gas: '0x5208', gasPrice };
 		}
 


### PR DESCRIPTION
This PR defines `gas` as '0x5208' (21000) when transaction `to` is undefined.