### PR TITLE
Fix BlockHistoryController

### DIFF
--- a/src/BlockHistoryController.test.ts
+++ b/src/BlockHistoryController.test.ts
@@ -49,15 +49,20 @@ describe('BlockHistoryController', () => {
 	});
 
 	it('should backfill correct number of blocks', () => {
+		const blockDepth = 50;
 		return new Promise((resolve) => {
 			const blockTracker = new BlockTracker({ provider: PROVIDER });
 			const controller = new BlockHistoryController({
-				blockDepth: 50,
+				blockDepth,
 				blockTracker,
 				provider: PROVIDER
 			});
 			controller.subscribe((state) => {
-				expect(state.recentBlocks.length).toBe(50);
+				const { recentBlocks } = state;
+				const firstBlockNumber = parseInt(recentBlocks[0].number, 16);
+				const lastBlockNumber = parseInt(recentBlocks[recentBlocks.length - 1].number, 16);
+				expect(recentBlocks.length).toBe(blockDepth);
+				expect(lastBlockNumber).toBe(firstBlockNumber + (blockDepth - 1));
 				resolve();
 			});
 		});

--- a/src/BlockHistoryController.ts
+++ b/src/BlockHistoryController.ts
@@ -106,9 +106,10 @@ export class BlockHistoryController extends BaseController<BlockHistoryConfig, B
 				})) as Block;
 				const currentBlockNumber = Number.parseInt(block.number, 16);
 				const blocksToFetch = Math.min(currentBlockNumber, this.internalBlockDepth);
+				const previousBlockNumber = currentBlockNumber - 1;
 				const blockNumbers = Array(blocksToFetch)
 					.fill(null)
-					.map((_: Block) => currentBlockNumber - 1);
+					.map((_: Block, index: number) => previousBlockNumber - index);
 				const newBlocks = await Promise.all(
 					blockNumbers.map((blockNumber: number) => this.getBlockByNumber(blockNumber))
 				);

--- a/src/BlockHistoryController.ts
+++ b/src/BlockHistoryController.ts
@@ -114,7 +114,8 @@ export class BlockHistoryController extends BaseController<BlockHistoryConfig, B
 					blockNumbers.map((blockNumber: number) => this.getBlockByNumber(blockNumber))
 				);
 				const filledBlocks = newBlocks.filter((newBlock) => newBlock);
-				filledBlocks.sort((a, b) => (a.number < b.number ? /* istanbul ignore next */ -1 : 1));
+				/* istanbul ignore next */
+				filledBlocks.sort((a, b) => (a.number < b.number ? -1 : 1));
 				const recentBlocks = filledBlocks.map((filledBlock) => this.mapGasPrices(filledBlock));
 				this.update({ recentBlocks });
 				this.backfilled = true;


### PR DESCRIPTION
There was a bug in the blocktracker's backfill function that was getting the same last block 40 times instead of the last 40 blocks.

Added a test to cover that scenario

Fixes #27 