### PR TITLE
Expose isUnlocked on KeyringController

### DIFF
--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -159,6 +159,15 @@ export class KeyringController extends BaseController<BaseConfig, KeyringState> 
 	}
 
 	/**
+	 * Returns the status of the vault
+	 *
+	 * @returns - Boolean returning true if the vault is unlocked
+	 */
+	isUnlocked(): boolean {
+		return privates.get(this).keyring.memStore.getState().isUnlocked;
+	}
+
+	/**
 	 * Gets the private key from the keyring controlling an address
 	 *
 	 * @param address - Address to export


### PR DESCRIPTION
After merging #37 we lost visibility of `isUnlocked` in the keyring state. This PR fixes that, which is currently breaking web3 injection on the mobile app.

(Test failures have nothing to do with this PR)