### PR TITLE
Add semaphore to lookupNetwork

### DIFF
--- a/src/NetworkController.ts
+++ b/src/NetworkController.ts
@@ -168,11 +168,11 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 	 * Refreshes the current network code
 	 */
 	async lookupNetwork() {
-		const releaseLock = await this.mutex.acquire();
 		/* istanbul ignore if */
 		if (!this.ethQuery || !this.ethQuery.sendAsync) {
 			return;
 		}
+		const releaseLock = await this.mutex.acquire();
 		this.ethQuery.sendAsync({ method: 'net_version' }, (error: Error, network: string) => {
 			this.update({ network: error ? /* istanbul ignore next*/ 'loading' : network });
 			releaseLock();

--- a/src/NetworkController.ts
+++ b/src/NetworkController.ts
@@ -4,6 +4,7 @@ const EthQuery = require('eth-query');
 const Subprovider = require('web3-provider-engine/subproviders/provider.js');
 const createInfuraProvider = require('eth-json-rpc-infura/src/createProvider');
 const createMetamaskProvider = require('web3-provider-engine//zero.js');
+const Mutex = require('await-semaphore').Mutex;
 
 /**
  * Human-readable network name
@@ -54,6 +55,7 @@ const LOCALHOST_RPC_URL = 'http://localhost:8545';
 export class NetworkController extends BaseController<NetworkConfig, NetworkState> {
 	private ethQuery: any;
 	private internalProviderConfig: ProviderConfig = {} as ProviderConfig;
+	private mutex = new Mutex();
 
 	private initializeProvider(type: NetworkType, rpcTarget?: string) {
 		switch (type) {
@@ -165,13 +167,15 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 	/**
 	 * Refreshes the current network code
 	 */
-	lookupNetwork() {
+	async lookupNetwork() {
+		const releaseLock = await this.mutex.acquire();
 		/* istanbul ignore if */
 		if (!this.ethQuery || !this.ethQuery.sendAsync) {
 			return;
 		}
 		this.ethQuery.sendAsync({ method: 'net_version' }, (error: Error, network: string) => {
 			this.update({ network: error ? /* istanbul ignore next*/ 'loading' : network });
+			releaseLock();
 		});
 	}
 


### PR DESCRIPTION
This PR makes sure that `lookupNetwork` in `NetworkController` is working as expected.

Issue:

Sometimes the provider is being initialized with the `defaultState` provider, that in this case is `rinkeby`, independent of the network that the client using GABA is trying to set.

Logic:

`this.ethQuery.sendAsync` it's always initialized with this `defaultState`, while at the same time the client tries to update the network using the same method. 
As it is an async method, sometimes the client request finishes first (for example setting the provider in `mainnet`), then `defaultState` (`rinkeby`) is the last to be updated, setting it as the `network`. Happening here https://github.com/MetaMask/gaba/blob/659ee7b7da6875f2ba9b3628444e2c986e27d394/src/NetworkController.ts#L173

To solve this a semaphore is added to make sure that the order of requests is valid. First default constructor, then whatever the client decides to do.