### PR TITLE
Don't use previous vault

### DIFF
--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -141,15 +141,9 @@ export class KeyringController extends BaseController<BaseConfig, KeyringState> 
 		const preferences = this.context.PreferencesController as PreferencesController;
 		const releaseLock = await this.mutex.acquire();
 		try {
-			let vault;
-			const accounts = await privates.get(this).keyring.getAccounts();
-			if (accounts.length > 0) {
-				vault = await this.fullUpdate();
-			} else {
-				vault = await privates.get(this).keyring.createNewVaultAndKeychain(password);
-				preferences.updateIdentities(await privates.get(this).keyring.getAccounts());
-				preferences.update({ selectedAddress: Object.keys(preferences.state.identities)[0] });
-			}
+			let vault = await privates.get(this).keyring.createNewVaultAndKeychain(password);
+			preferences.updateIdentities(await privates.get(this).keyring.getAccounts());
+			preferences.update({ selectedAddress: Object.keys(preferences.state.identities)[0] });
 			releaseLock();
 			return vault;
 		} catch (err) {

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -141,7 +141,7 @@ export class KeyringController extends BaseController<BaseConfig, KeyringState> 
 		const preferences = this.context.PreferencesController as PreferencesController;
 		const releaseLock = await this.mutex.acquire();
 		try {
-			let vault = await privates.get(this).keyring.createNewVaultAndKeychain(password);
+			const vault = await privates.get(this).keyring.createNewVaultAndKeychain(password);
 			preferences.updateIdentities(await privates.get(this).keyring.getAccounts());
 			preferences.update({ selectedAddress: Object.keys(preferences.state.identities)[0] });
 			releaseLock();

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -144,6 +144,7 @@ export class KeyringController extends BaseController<BaseConfig, KeyringState> 
 			const vault = await privates.get(this).keyring.createNewVaultAndKeychain(password);
 			preferences.updateIdentities(await privates.get(this).keyring.getAccounts());
 			preferences.update({ selectedAddress: Object.keys(preferences.state.identities)[0] });
+			this.fullUpdate();
 			releaseLock();
 			return vault;
 		} catch (err) {


### PR DESCRIPTION
Before this PR the keyring was returning the latest existent vault which was causing the following problem.

I'm logged in with keyring A which has password B
I log out.
I create a new wallet with password C
Now I get keyring A with password C.

TL;DR: When you create a new wallet it should ignore whatever wallet existed before and create a new one.