### PR TITLE
Keyrings needs to update after import from seed

### DIFF
--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -123,6 +123,7 @@ export class KeyringController extends BaseController<BaseConfig, KeyringState> 
 			const vault = await privates.get(this).keyring.createNewVaultAndRestore(password, seed);
 			preferences.updateIdentities(await privates.get(this).keyring.getAccounts());
 			preferences.update({ selectedAddress: Object.keys(preferences.state.identities)[0] });
+			this.fullUpdate();
 			releaseLock();
 			return vault;
 		} catch (err) {


### PR DESCRIPTION
Otherwise there are no accounts exposed until the next time GABA initializes.

This fixes an issue on the mobile app that makes the account list to be empty after importing from seed.