### PR TITLE
Only update TransactionController state if got updates

### DIFF
--- a/src/TransactionController.test.ts
+++ b/src/TransactionController.test.ts
@@ -153,6 +153,18 @@ describe('TransactionController', () => {
 		func.restore();
 	});
 
+	it('should not update the state if there are no updates on transaction statuses', () => {
+		return new Promise((resolve) => {
+			const controller = new TransactionController({ interval: 10 });
+			const func = stub(controller, 'update');
+			setTimeout(() => {
+				expect(func.called).toBe(false);
+				func.restore();
+				resolve();
+			}, 20);
+		});
+	});
+
 	it('should throw when adding invalid transaction', () => {
 		return new Promise(async (resolve) => {
 			const controller = new TransactionController();
@@ -340,6 +352,7 @@ describe('TransactionController', () => {
 				transactionHash: '1337'
 			} as any);
 			controller.state.transactions.push({} as any);
+
 			controller.hub.once(`${controller.state.transactions[0].id}:confirmed`, () => {
 				expect(controller.state.transactions[0].status).toBe('confirmed');
 				resolve();

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -438,6 +438,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const { transactions } = this.state;
 		const network = this.context.NetworkController;
 		const currentNetworkID = network.state.network;
+		let gotUpdates = false;
 		safelyExecute(() =>
 			Promise.all(
 				transactions.map(async (meta, index) => {
@@ -447,12 +448,15 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 						if (txObj && txObj.blockNumber) {
 							transactions[index].status = 'confirmed';
 							this.hub.emit(`${meta.id}:confirmed`, meta);
+							gotUpdates = true;
 						}
 					}
 				})
 			)
 		);
-		this.update({ transactions: [...transactions] });
+		if (gotUpdates) {
+			this.update({ transactions: [...transactions] });
+		}
 	}
 
 	/**

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -439,7 +439,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const network = this.context.NetworkController;
 		const currentNetworkID = network.state.network;
 		let gotUpdates = false;
-		safelyExecute(() =>
+		await safelyExecute(() =>
 			Promise.all(
 				transactions.map(async (meta, index) => {
 					if (meta.status === 'submitted' && meta.networkID === currentNetworkID) {
@@ -454,7 +454,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 				})
 			)
 		);
-		/* istanbul ignore next */
+		/* istanbul ignore else */
 		if (gotUpdates) {
 			this.update({ transactions: [...transactions] });
 		}

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -454,6 +454,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 				})
 			)
 		);
+		/* istanbul ignore next */
 		if (gotUpdates) {
 			this.update({ transactions: [...transactions] });
 		}


### PR DESCRIPTION
Because queryTransactionStatuses is running inside a setInterval we're telling GABA that the state was updated even when there are no changes.

This PR adds a flag to make sure the state gets updated only when at least 1 TX status changed.