### PR TITLE
Set balanc3 autoconversion off

### DIFF
--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -65,7 +65,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	private tokenList: Token[] = [];
 
 	private getPricingURL(query: string) {
-		return `https://exchanges.balanc3.net/pie?${query}&autoConversion=true`;
+		return `https://exchanges.balanc3.net/pie?${query}&autoConversion=false`;
 	}
 
 	/**


### PR DESCRIPTION
As explained here https://github.com/MetaMask/metamask-extension/pull/6005, for some tokens balanc2 returns the usd conversion not the native currency being asked.