### PR TITLE
Add contract ownerOf support

### DIFF
--- a/src/AssetsContractController.test.ts
+++ b/src/AssetsContractController.test.ts
@@ -48,4 +48,10 @@ describe('AssetsContractController', () => {
 		const tokenId = await assetsContract.getCollectibleTokenURI(GODSADDRESS, 0);
 		expect(tokenId).toEqual('https://api.godsunchained.com/card/0');
 	});
+
+	it('should get collectible ownership', async () => {
+		assetsContract.configure({ provider: MAINNET_PROVIDER });
+		const tokenId = await assetsContract.getOwnerOf(GODSADDRESS, 148332);
+		expect(tokenId).not.toEqual('');
+	});
 });

--- a/src/AssetsContractController.ts
+++ b/src/AssetsContractController.ts
@@ -158,6 +158,27 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
 			});
 		});
 	}
+
+	/**
+	 * Query for owner for a given ERC721 asset
+	 *
+	 * @param address - ERC721 asset contract address
+	 * @param tokenId - ERC721 asset identifier
+	 * @returns - Promise resolving to the owner address
+	 */
+	async getOwnerOf(address: string, tokenId: number): Promise<string> {
+		const contract = this.web3.eth.contract(abiERC721).at(address);
+		return new Promise<string>((resolve, reject) => {
+			contract.ownerOf(tokenId, (error: Error, result: string) => {
+				/* istanbul ignore if */
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(result);
+			});
+		});
+	}
 }
 
 export default AssetsContractController;

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -65,7 +65,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	private tokenList: Token[] = [];
 
 	private getPricingURL(query: string) {
-		return `https://exchanges.balanc3.net/pie?${query}&autoConversion=true`;
+		return `https://exchanges.balanc3.net/pie?${query}&autoConversion=false`;
 	}
 
 	/**


### PR DESCRIPTION
This PR adds support for ERC721 `ownerOf` method in `AssetsContractController`.