### PR TITLE
Avoid 2100 requests / hour to Infura

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1531,10 +1531,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-    },
     "binary-extensions": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -2599,8 +2595,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereumjs-abi": {
@@ -2719,8 +2724,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereum-common": {
@@ -8449,6 +8463,11 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "single-call-balance-checker-abi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/single-call-balance-checker-abi/-/single-call-balance-checker-abi-1.0.0.tgz",
+      "integrity": "sha512-T5fRBJHmGEMe76JFGB36gcZnOh1ip2S7Qsp7cwmwrfMRjadxTe02zJHtXERpnQf2yvSqNWRxvae5f6e8v4rhng=="
+    },
     "sinon": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
@@ -9592,11 +9611,16 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
         "xmlhttprequest": "*"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+        }
       }
     },
     "web3-provider-engine": {
@@ -9644,8 +9668,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereumjs-abi": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "isomorphic-fetch": "^2.2.1",
     "jsonschema": "^1.2.4",
     "percentile": "^1.2.1",
+    "single-call-balance-checker-abi": "^1.0.0",
     "uuid": "^3.3.2",
     "web3": "^0.20.7",
     "web3-provider-engine": "github:metamask/provider-engine#feature/getaccounts-payload"

--- a/src/AssetsContractController.test.ts
+++ b/src/AssetsContractController.test.ts
@@ -53,6 +53,6 @@ describe('AssetsContractController', () => {
 	it('should get balances in a single call', async () => {
 		assetsContract.configure({ provider: MAINNET_PROVIDER });
 		const balances = await assetsContract.getBalancesInSingleCall(DAI_ADDRESS, [DAI_ADDRESS]);
-		expect(balances['0xE46aBAf75cFbFF815c0b7FfeD6F02B0760eA27f1']).not.toEqual(0);
+		expect(balances[DAI_ADDRESS]).not.toEqual(0);
 	});
 });

--- a/src/AssetsContractController.test.ts
+++ b/src/AssetsContractController.test.ts
@@ -3,6 +3,7 @@ const HttpProvider = require('ethjs-provider-http');
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io');
 const GODSADDRESS = '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab';
 const CKADDRESS = '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d';
+const DAI_ADDRESS = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359';
 
 describe('AssetsContractController', () => {
 	let assetsContract: AssetsContractController;
@@ -47,5 +48,11 @@ describe('AssetsContractController', () => {
 		assetsContract.configure({ provider: MAINNET_PROVIDER });
 		const tokenId = await assetsContract.getCollectibleTokenURI(GODSADDRESS, 0);
 		expect(tokenId).toEqual('https://api.godsunchained.com/card/0');
+	});
+
+	it('should get balances in a single call', async () => {
+		assetsContract.configure({ provider: MAINNET_PROVIDER });
+		const balances = await assetsContract.getBalancesInSingleCall(DAI_ADDRESS, [DAI_ADDRESS]);
+		expect(balances['0xE46aBAf75cFbFF815c0b7FfeD6F02B0760eA27f1']).not.toEqual(0);
 	});
 });

--- a/src/AssetsContractController.ts
+++ b/src/AssetsContractController.ts
@@ -5,10 +5,10 @@ const BN = require('ethereumjs-util').BN;
 const Web3 = require('web3');
 const abiERC20 = require('human-standard-token-abi');
 const abiERC721 = require('human-standard-collectible-abi');
-const abiSingleCallContract = require('single-call-balance-checker-abi');
+const abiSingleCallBalancesContract = require('single-call-balance-checker-abi');
 const ERC721METADATA_INTERFACE_ID = '0x5b5e139f';
 const ERC721ENUMERABLE_INTERFACE_ID = '0x780e9d63';
-const SINGLE_CALL_MAINNET_ADDRESS = '0xb1f8e55c7f64d203c1400b9d8555d050f94adf39';
+const SINGLE_CALL_BALANCES_ADDRESS = '0xb1f8e55c7f64d203c1400b9d8555d050f94adf39';
 
 /**
  * @type AssetsContractConfig
@@ -178,7 +178,7 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
 	 * @returns - Promise resolving to the 'tokenURI'
 	 */
 	async getBalancesInSingleCall(selectedAddress: string, tokensToDetect: string[]) {
-		const contract = this.web3.eth.contract(abiSingleCallContract).at(SINGLE_CALL_MAINNET_ADDRESS);
+		const contract = this.web3.eth.contract(abiSingleCallBalancesContract).at(SINGLE_CALL_BALANCES_ADDRESS);
 		return new Promise<BalanceMap>((resolve, reject) => {
 			contract.balances([selectedAddress], tokensToDetect, (error: Error, result: string) => {
 				/* istanbul ignore if */


### PR DESCRIPTION
The `AssetsDetectionController` has been querying every single ERC20 contract in the `eth-contract-map` package (106 in total) every 3 minutes to see if the `selectedAddress` has a positive balance and start watching that token.  

That can be done in a single call by querying a smart contract: https://github.com/wbobeirne/eth-balance-checker/blob/master/contracts/BalanceChecker.sol

So instead of 106 requests / 3 minutes, we're doing 1, which results in 2100 requests less made to Infura per hour.

CC: @frankiebee 

I'll submit a similar PR to the extension shortly since the difference is huge and it's not that big of a change.