### PR TITLE
Introduce collectible contract

### DIFF
--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -325,7 +325,7 @@ describe('AssetsController', () => {
 				logo: 'logo',
 				name: 'name',
 				symbol: 'NM',
-				total_supply: 10
+				totalSupply: 10
 			}
 		]);
 	});
@@ -340,7 +340,7 @@ describe('AssetsController', () => {
 				logo: 'logo',
 				name: 'name',
 				symbol: 'NM',
-				total_supply: 10
+				totalSupply: 10
 			}
 		]);
 	});
@@ -363,7 +363,7 @@ describe('AssetsController', () => {
 				logo: 'other logo',
 				name: 'other name',
 				symbol: 'ON',
-				total_supply: 11
+				totalSupply: 11
 			}
 		]);
 	});

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -35,6 +35,7 @@ describe('AssetsController', () => {
 
 	it('should set default state', () => {
 		expect(assetsController.state).toEqual({
+			allCollectibleContracts: [],
 			allCollectibles: {},
 			allTokens: {},
 			collectibles: [],
@@ -313,6 +314,58 @@ describe('AssetsController', () => {
 			name: '',
 			tokenId: 1
 		});
+	});
+
+	it('should add collectible contract', async () => {
+		await assetsController.addCollectibleContract('0x8C9b', 'name', 'NM', 'logo', 'description', 10);
+		expect(assetsController.state.allCollectibleContracts).toEqual([
+			{
+				address: '0x8C9b',
+				description: 'description',
+				logo: 'logo',
+				name: 'name',
+				symbol: 'NM',
+				total_supply: 10
+			}
+		]);
+	});
+
+	it('should not add  duplicated collectible contract', async () => {
+		await assetsController.addCollectibleContract('0x8C9b', 'name', 'NM', 'logo', 'description', 10);
+		await assetsController.addCollectibleContract('0x8C9b', 'name', 'NM', 'logo', 'description', 10);
+		expect(assetsController.state.allCollectibleContracts).toEqual([
+			{
+				address: '0x8C9b',
+				description: 'description',
+				logo: 'logo',
+				name: 'name',
+				symbol: 'NM',
+				total_supply: 10
+			}
+		]);
+	});
+
+	it('should remove collectible contract', async () => {
+		await assetsController.addCollectibleContract('0x8c9b', 'name', 'NM', 'logo', 'description', 10);
+		await assetsController.addCollectibleContract(
+			'0x8c9C',
+			'other name',
+			'ON',
+			'other logo',
+			'other description',
+			11
+		);
+		await assetsController.removeCollectibleContract('0x8c9b');
+		expect(assetsController.state.allCollectibleContracts).toEqual([
+			{
+				address: '0x8c9C',
+				description: 'other description',
+				logo: 'other logo',
+				name: 'other name',
+				symbol: 'ON',
+				total_supply: 11
+			}
+		]);
 	});
 
 	it('should subscribe to new sibling preference controllers', async () => {

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -66,7 +66,7 @@ export interface MappedContract {
  * @property address - Contract address
  * @property symbol - Contract symbol
  * @property description - Contract description
- * @property total_supply - Contract total_supply
+ * @property totalSupply - Contract total supply
  */
 export interface CollectibleContract {
 	name: string;
@@ -74,7 +74,7 @@ export interface CollectibleContract {
 	address: string;
 	symbol: string;
 	description: string;
-	total_supply: number;
+	totalSupply: number;
 }
 
 /**
@@ -285,7 +285,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		symbol: string,
 		logo: string,
 		description: string,
-		total_supply: number
+		totalSupply: number
 	): Promise<CollectibleContract[]> {
 		const releaseLock = await this.mutex.acquire();
 		address = toChecksumAddress(address);
@@ -297,7 +297,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			releaseLock();
 			return allCollectibleContracts;
 		}
-		const newEntry: CollectibleContract = { address, logo, name, symbol, description, total_supply };
+		const newEntry: CollectibleContract = { address, logo, name, symbol, description, totalSupply };
 		const newCollectibleContracts = [...allCollectibleContracts, newEntry];
 		this.update({ allCollectibleContracts: newCollectibleContracts });
 		releaseLock();

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -22,7 +22,13 @@ describe('ComposableController', () => {
 		expect(controller.state).toEqual({
 			AddressBookController: { addressBook: [] },
 			AssetsContractController: {},
-			AssetsController: { allTokens: {}, allCollectibles: {}, collectibles: [], tokens: [] },
+			AssetsController: {
+				allCollectibleContracts: [],
+				allCollectibles: {},
+				allTokens: {},
+				collectibles: [],
+				tokens: []
+			},
 			CurrencyRateController: {
 				conversionDate: 0,
 				conversionRate: 0,
@@ -56,6 +62,7 @@ describe('ComposableController', () => {
 		]);
 		expect(controller.flatState).toEqual({
 			addressBook: [],
+			allCollectibleContracts: [],
 			allCollectibles: {},
 			allTokens: {},
 			collectibles: [],
@@ -91,6 +98,7 @@ describe('ComposableController', () => {
 		addressContext.set('1337', 'foo');
 		expect(controller.flatState).toEqual({
 			addressBook: [{ address: '1337', name: 'foo' }],
+			allCollectibleContracts: [],
 			allCollectibles: {},
 			allTokens: {},
 			collectibles: [],


### PR DESCRIPTION
This PR adds a new interface called `CollectibleContract` and related methods to `AssetsController` to handle collectible contract information.