### PR TITLE
Reorder collectibles detection and structure

### DIFF
--- a/src/AssetsContractController.test.ts
+++ b/src/AssetsContractController.test.ts
@@ -52,13 +52,19 @@ describe('AssetsContractController', () => {
 
 	it('should get collectible name', async () => {
 		assetsContract.configure({ provider: MAINNET_PROVIDER });
-		const name = await assetsContract.getCollectibleContractName(GODSADDRESS);
+		const name = await assetsContract.getAssetName(GODSADDRESS);
 		expect(name).toEqual('Gods Unchained');
 	});
 	it('should get collectible symbol', async () => {
 		assetsContract.configure({ provider: MAINNET_PROVIDER });
-		const symbol = await assetsContract.getCollectibleContractSymbol(GODSADDRESS);
+		const symbol = await assetsContract.getAssetSymbol(GODSADDRESS);
 		expect(symbol).toEqual('GODS');
+	});
+
+	it('should get token decimals', async () => {
+		assetsContract.configure({ provider: MAINNET_PROVIDER });
+		const symbol = await assetsContract.getTokenDecimals(DAI_ADDRESS);
+		expect(Number(symbol)).toEqual(18);
 	});
 
 	it('should get collectible ownership', async () => {

--- a/src/AssetsContractController.test.ts
+++ b/src/AssetsContractController.test.ts
@@ -50,6 +50,17 @@ describe('AssetsContractController', () => {
 		expect(tokenId).toEqual('https://api.godsunchained.com/card/0');
 	});
 
+	it('should get collectible name', async () => {
+		assetsContract.configure({ provider: MAINNET_PROVIDER });
+		const name = await assetsContract.getCollectibleContractName(GODSADDRESS);
+		expect(name).toEqual('Gods Unchained');
+	});
+	it('should get collectible symbol', async () => {
+		assetsContract.configure({ provider: MAINNET_PROVIDER });
+		const symbol = await assetsContract.getCollectibleContractSymbol(GODSADDRESS);
+		expect(symbol).toEqual('GODS');
+	});
+
 	it('should get collectible ownership', async () => {
 		assetsContract.configure({ provider: MAINNET_PROVIDER });
 		const tokenId = await assetsContract.getOwnerOf(GODSADDRESS, 148332);

--- a/src/AssetsContractController.ts
+++ b/src/AssetsContractController.ts
@@ -173,12 +173,32 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
 	}
 
 	/**
+	 * Query for name for a given ERC20 asset
+	 *
+	 * @param address - ERC20 asset contract address
+	 * @returns - Promise resolving to the 'decimals'
+	 */
+	async getTokenDecimals(address: string): Promise<string> {
+		const contract = this.web3.eth.contract(abiERC20).at(address);
+		return new Promise<string>((resolve, reject) => {
+			contract.decimals((error: Error, result: string) => {
+				/* istanbul ignore if */
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(result);
+			});
+		});
+	}
+
+	/**
 	 * Query for name for a given asset
 	 *
-	 * @param address - ERC721 asset contract address
+	 * @param address - ERC721 or ERC20 asset contract address
 	 * @returns - Promise resolving to the 'name'
 	 */
-	async getCollectibleContractName(address: string): Promise<string> {
+	async getAssetName(address: string): Promise<string> {
 		const contract = this.web3.eth.contract(abiERC721).at(address);
 		return new Promise<string>((resolve, reject) => {
 			contract.name((error: Error, result: string) => {
@@ -195,10 +215,10 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
 	/**
 	 * Query for symbol for a given asset
 	 *
-	 * @param address - ERC721 asset contract address
+	 * @param address - ERC721 or ERC20 asset contract address
 	 * @returns - Promise resolving to the 'symbol'
 	 */
-	async getCollectibleContractSymbol(address: string): Promise<string> {
+	async getAssetSymbol(address: string): Promise<string> {
 		const contract = this.web3.eth.contract(abiERC721).at(address);
 		return new Promise<string>((resolve, reject) => {
 			contract.symbol((error: Error, result: string) => {

--- a/src/AssetsContractController.ts
+++ b/src/AssetsContractController.ts
@@ -172,6 +172,34 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
 		});
 	}
 
+	async getCollectibleContractName(address: string): Promise<string> {
+		const contract = this.web3.eth.contract(abiERC721).at(address);
+		return new Promise<string>((resolve, reject) => {
+			contract.name((error: Error, result: string) => {
+				/* istanbul ignore if */
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(result);
+			});
+		});
+	}
+
+	async getCollectibleContractSymbol(address: string): Promise<string> {
+		const contract = this.web3.eth.contract(abiERC721).at(address);
+		return new Promise<string>((resolve, reject) => {
+			contract.symbol((error: Error, result: string) => {
+				/* istanbul ignore if */
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(result);
+			});
+		});
+	}
+
 	/**
 	 * Query for owner for a given ERC721 asset
 	 *

--- a/src/AssetsContractController.ts
+++ b/src/AssetsContractController.ts
@@ -172,6 +172,12 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
 		});
 	}
 
+	/**
+	 * Query for name for a given asset
+	 *
+	 * @param address - ERC721 asset contract address
+	 * @returns - Promise resolving to the 'name'
+	 */
 	async getCollectibleContractName(address: string): Promise<string> {
 		const contract = this.web3.eth.contract(abiERC721).at(address);
 		return new Promise<string>((resolve, reject) => {
@@ -186,6 +192,12 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
 		});
 	}
 
+	/**
+	 * Query for symbol for a given asset
+	 *
+	 * @param address - ERC721 asset contract address
+	 * @returns - Promise resolving to the 'symbol'
+	 */
 	async getCollectibleContractSymbol(address: string): Promise<string> {
 		const contract = this.web3.eth.contract(abiERC721).at(address);
 		return new Promise<string>((resolve, reject) => {

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -240,7 +240,7 @@ describe('AssetsController', () => {
 			description: 'Description',
 			image: 'url',
 			name: 'Name',
-			tokenId: 10
+			tokenId: 1
 		});
 	});
 

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -8,7 +8,7 @@ import { AssetsContractController } from './AssetsContractController';
 
 const HttpProvider = require('ethjs-provider-http');
 const TOKENS = [{ address: '0xfoO', symbol: 'bar', decimals: 2 }];
-const COLLECTIBLES = [{ address: '0xfoO', image: 'url', name: 'name', tokenId: 1234 }];
+const COLLECTIBLES = [{ address: '0xfoO', description: undefined, image: 'url', name: 'name', tokenId: 1234 }];
 const GODSADDRESS = '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab';
 const CKADDRESS = '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d';
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io');
@@ -135,6 +135,7 @@ describe('AssetsController', () => {
 		expect(assetsController.state.collectibles).toEqual([
 			{
 				address: '0xfoO',
+				description: '',
 				image: '',
 				name: '',
 				tokenId: 1234
@@ -148,6 +149,7 @@ describe('AssetsController', () => {
 		expect(assetsController.state.collectibles).toEqual([
 			{
 				address: '0x8c9b261Faef3b3C2e64ab5E58e04615F8c788099',
+				description: '',
 				image: '',
 				name: 'LucidSight-MLB-NFT',
 				tokenId: 1
@@ -164,6 +166,7 @@ describe('AssetsController', () => {
 		expect(assetsController.state.collectibles).toEqual([
 			{
 				address: '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
+				description: '',
 				image: 'https://api.godsunchained.com/v0/image/7',
 				name: 'Broken Harvester',
 				tokenId: 1
@@ -184,6 +187,7 @@ describe('AssetsController', () => {
 		expect(assetsController.state.collectibles).toEqual([
 			{
 				address: '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d',
+				description: '',
 				image: 'https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/1.png',
 				name: 'Genesis',
 				tokenId: 1
@@ -204,6 +208,7 @@ describe('AssetsController', () => {
 		preferences.update({ selectedAddress: firstAddress });
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0xfoO',
+			description: undefined,
 			image: 'url',
 			name: 'name',
 			tokenId: 1234
@@ -223,6 +228,7 @@ describe('AssetsController', () => {
 		network.update({ provider: { type: firstNetworkType } });
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0xfoO',
+			description: undefined,
 			image: 'url',
 			name: 'name',
 			tokenId: 1234
@@ -253,6 +259,7 @@ describe('AssetsController', () => {
 		preferences.update({ selectedAddress: firstAddress });
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0xFOu',
+			description: undefined,
 			image: 'url',
 			name: 'name',
 			tokenId: 4321
@@ -275,6 +282,7 @@ describe('AssetsController', () => {
 		network.update({ provider: { type: firstNetworkType } });
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0xFOu',
+			description: undefined,
 			image: 'url',
 			name: 'name',
 			tokenId: 4321
@@ -303,6 +311,7 @@ describe('AssetsController', () => {
 		await assetsController.addCollectible('0x06012c8cf97BEaD5deAe237070F9587f8E7A266d', 740632);
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d',
+			description: '',
 			image: 'https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/1.png',
 			name: 'TestName',
 			tokenId: 740632
@@ -310,6 +319,7 @@ describe('AssetsController', () => {
 		await assetsController.addCollectible('foo', 1);
 		expect(assetsController.state.collectibles[1]).toEqual({
 			address: '0xfoO',
+			description: '',
 			image: '',
 			name: '',
 			tokenId: 1

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -252,18 +252,18 @@ describe('AssetsController', () => {
 		await assetsController.addCollectible(KUDOSADDRESS, 1203);
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0x2aEa4Add166EBf38b63d09a75dE1a7b94Aa24163',
-			description: '',
+			description: undefined,
 			image: 'Kudos Image',
 			name: 'Kudos Name',
 			tokenId: 1203
 		});
 		expect(assetsController.state.collectibleContracts[0]).toEqual({
 			address: '0x2aEa4Add166EBf38b63d09a75dE1a7b94Aa24163',
-			description: '',
-			logo: '',
+			description: undefined,
+			logo: undefined,
 			name: 'KudosToken',
 			symbol: 'KDO',
-			totalSupply: ''
+			totalSupply: undefined
 		});
 	});
 
@@ -276,18 +276,18 @@ describe('AssetsController', () => {
 		await assetsController.addCollectible('0x2aE', 1203);
 		expect(assetsController.state.collectibles[0]).toEqual({
 			address: '0x2aE',
-			description: '',
-			image: '',
-			name: '',
+			description: undefined,
+			image: undefined,
+			name: undefined,
 			tokenId: 1203
 		});
 		expect(assetsController.state.collectibleContracts[0]).toEqual({
 			address: '0x2aE',
-			description: '',
-			logo: '',
-			name: '',
-			symbol: '',
-			totalSupply: ''
+			description: undefined,
+			logo: undefined,
+			name: undefined,
+			symbol: undefined,
+			totalSupply: undefined
 		});
 	});
 

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -9,6 +9,7 @@ import { AssetsContractController } from './AssetsContractController';
 const HttpProvider = require('ethjs-provider-http');
 const KUDOSADDRESS = '0x2aea4add166ebf38b63d09a75de1a7b94aa24163';
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io');
+const OPEN_SEA_API = 'https://api.opensea.io/api/v1/';
 
 describe('AssetsController', () => {
 	let assetsController: AssetsController;
@@ -26,7 +27,7 @@ describe('AssetsController', () => {
 		new ComposableController([assetsController, assetsContract, network, preferences]);
 
 		getOnce(
-			'https://api.opensea.io/api/v1/asset_contract/0xfoO',
+			OPEN_SEA_API + 'asset_contract/0xfoO',
 			() => ({
 				body: JSON.stringify({
 					description: 'Description',
@@ -39,7 +40,7 @@ describe('AssetsController', () => {
 			{ overwriteRoutes: true }
 		);
 		getOnce(
-			'https://api.opensea.io/api/v1/asset_contract/0xFOu',
+			OPEN_SEA_API + 'asset_contract/0xFOu',
 			() => ({
 				body: JSON.stringify({
 					description: 'Description',
@@ -52,7 +53,7 @@ describe('AssetsController', () => {
 			{ overwriteRoutes: true }
 		);
 		getOnce(
-			'https://api.opensea.io/api/v1/asset/0xfoO/1',
+			OPEN_SEA_API + 'asset/0xfoO/1',
 			() => ({
 				body: JSON.stringify({
 					description: 'Description',
@@ -63,7 +64,7 @@ describe('AssetsController', () => {
 			{ overwriteRoutes: true }
 		);
 		getOnce(
-			'https://api.opensea.io/api/v1/asset/0x2aEa4Add166EBf38b63d09a75dE1a7b94Aa24163/1203',
+			OPEN_SEA_API + 'asset/0x2aEa4Add166EBf38b63d09a75dE1a7b94Aa24163/1203',
 			() => ({
 				body: JSON.stringify({
 					description: 'Kudos Description',
@@ -84,14 +85,14 @@ describe('AssetsController', () => {
 			{ overwriteRoutes: true }
 		);
 		getOnce(
-			'https://api.opensea.io/api/v1/asset/0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab/798958393',
+			OPEN_SEA_API + 'asset/0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab/798958393',
 			() => ({
 				throws: new TypeError('Failed to fetch')
 			}),
 			{ overwriteRoutes: true }
 		);
 		getOnce(
-			'https://api.opensea.io/api/v1/asset_contract/0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
+			OPEN_SEA_API + 'asset_contract/0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
 			() => ({
 				throws: new TypeError('Failed to fetch')
 			}),

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -327,7 +327,7 @@ describe('AssetsController', () => {
 	});
 
 	it('should add collectible contract', async () => {
-		await assetsController.addCollectibleContract('0x8C9b', 'name', 'NM', 'logo', 'description', 10);
+		await assetsController.addCollectibleContract('0x8C9b');
 		expect(assetsController.state.allCollectibleContracts).toEqual([
 			{
 				address: '0x8C9b',
@@ -341,8 +341,8 @@ describe('AssetsController', () => {
 	});
 
 	it('should not add  duplicated collectible contract', async () => {
-		await assetsController.addCollectibleContract('0x8C9b', 'name', 'NM', 'logo', 'description', 10);
-		await assetsController.addCollectibleContract('0x8C9b', 'name', 'NM', 'logo', 'description', 10);
+		await assetsController.addCollectibleContract('0x8C9b');
+		await assetsController.addCollectibleContract('0x8C9b');
 		expect(assetsController.state.allCollectibleContracts).toEqual([
 			{
 				address: '0x8C9b',
@@ -356,15 +356,8 @@ describe('AssetsController', () => {
 	});
 
 	it('should remove collectible contract', async () => {
-		await assetsController.addCollectibleContract('0x8c9b', 'name', 'NM', 'logo', 'description', 10);
-		await assetsController.addCollectibleContract(
-			'0x8c9C',
-			'other name',
-			'ON',
-			'other logo',
-			'other description',
-			11
-		);
+		await assetsController.addCollectibleContract('0x8c9b');
+		await assetsController.addCollectibleContract('0x8c9C');
 		await assetsController.removeCollectibleContract('0x8c9b');
 		expect(assetsController.state.allCollectibleContracts).toEqual([
 			{

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -50,7 +50,7 @@ describe('AssetsController', () => {
 					image_url: 'url',
 					name: 'Name',
 					symbol: 'FOU',
-					total_supply: 0
+					total_supply: 10
 				})
 			}),
 			{ overwriteRoutes: true }
@@ -244,7 +244,7 @@ describe('AssetsController', () => {
 			description: 'Description',
 			image: 'url',
 			name: 'Name',
-			tokenId: 1
+			tokenId: 10
 		});
 	});
 
@@ -262,11 +262,35 @@ describe('AssetsController', () => {
 		});
 		expect(assetsController.state.collectibleContracts[0]).toEqual({
 			address: '0x2aEa4Add166EBf38b63d09a75dE1a7b94Aa24163',
-			description: undefined,
-			logo: undefined,
+			description: '',
+			logo: '',
 			name: 'KudosToken',
 			symbol: 'KDO',
-			totalSupply: undefined
+			totalSupply: ''
+		});
+	});
+
+	it('should add collectible and get collectible contract with no information if no contract nor api', async () => {
+		assetsContract.configure({ provider: MAINNET_PROVIDER });
+		sandbox.stub(assetsController, 'getCollectibleContractInformationFromApi' as any).returns(undefined);
+		sandbox.stub(assetsController, 'getCollectibleInformationFromApi' as any).returns(undefined);
+		sandbox.stub(assetsController, 'getCollectibleInformationFromTokenURI' as any).returns(undefined);
+		sandbox.stub(assetsController, 'getCollectibleContractInformationFromContract' as any).returns(undefined);
+		await assetsController.addCollectible('0x2aE', 1203);
+		expect(assetsController.state.collectibles[0]).toEqual({
+			address: '0x2aE',
+			description: '',
+			image: '',
+			name: '',
+			tokenId: 1203
+		});
+		expect(assetsController.state.collectibleContracts[0]).toEqual({
+			address: '0x2aE',
+			description: '',
+			logo: '',
+			name: '',
+			symbol: '',
+			totalSupply: ''
 		});
 	});
 

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -7,10 +7,6 @@ import { NetworkController } from './NetworkController';
 import { AssetsContractController } from './AssetsContractController';
 
 const HttpProvider = require('ethjs-provider-http');
-const TOKENS = [{ address: '0xfoO', symbol: 'bar', decimals: 2 }];
-const COLLECTIBLES = [{ address: '0xfoO', description: undefined, image: 'url', name: 'name', tokenId: 1234 }];
-const GODSADDRESS = '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab';
-const CKADDRESS = '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d';
 const KUDOSADDRESS = '0x2aea4add166ebf38b63d09a75de1a7b94aa24163';
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io');
 

--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -326,51 +326,6 @@ describe('AssetsController', () => {
 		});
 	});
 
-	it('should add collectible contract', async () => {
-		await assetsController.addCollectibleContract('0x8C9b');
-		expect(assetsController.state.allCollectibleContracts).toEqual([
-			{
-				address: '0x8C9b',
-				description: 'description',
-				logo: 'logo',
-				name: 'name',
-				symbol: 'NM',
-				totalSupply: 10
-			}
-		]);
-	});
-
-	it('should not add  duplicated collectible contract', async () => {
-		await assetsController.addCollectibleContract('0x8C9b');
-		await assetsController.addCollectibleContract('0x8C9b');
-		expect(assetsController.state.allCollectibleContracts).toEqual([
-			{
-				address: '0x8C9b',
-				description: 'description',
-				logo: 'logo',
-				name: 'name',
-				symbol: 'NM',
-				totalSupply: 10
-			}
-		]);
-	});
-
-	it('should remove collectible contract', async () => {
-		await assetsController.addCollectibleContract('0x8c9b');
-		await assetsController.addCollectibleContract('0x8c9C');
-		await assetsController.removeCollectibleContract('0x8c9b');
-		expect(assetsController.state.allCollectibleContracts).toEqual([
-			{
-				address: '0x8c9C',
-				description: 'other description',
-				logo: 'other logo',
-				name: 'other name',
-				symbol: 'ON',
-				totalSupply: 11
-			}
-		]);
-	});
-
 	it('should subscribe to new sibling preference controllers', async () => {
 		const networkType = 'rinkeby';
 		const address = '0x123';

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -4,7 +4,7 @@ import PreferencesController from './PreferencesController';
 import NetworkController, { NetworkType } from './NetworkController';
 import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
-import { manageCollectibleImage, safelyExecute, handleFetch } from './util';
+import { safelyExecute, handleFetch } from './util';
 
 const { toChecksumAddress } = require('ethereumjs-util');
 const Mutex = require('await-semaphore').Mutex;

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -22,9 +22,9 @@ const Mutex = require('await-semaphore').Mutex;
  */
 export interface Collectible {
 	address: string;
-	description: string;
-	image: string;
-	name: string;
+	description?: string;
+	image?: string;
+	name?: string;
 	tokenId: number;
 }
 
@@ -41,12 +41,12 @@ export interface Collectible {
  * @property totalSupply - Contract total supply
  */
 export interface CollectibleContract {
-	name: string;
-	logo: string;
+	name?: string;
+	logo?: string;
 	address: string;
-	symbol: string;
-	description: string;
-	totalSupply: string;
+	symbol?: string;
+	description?: string;
+	totalSupply?: string;
 }
 
 /**
@@ -61,11 +61,11 @@ export interface CollectibleContract {
  * @property total_supply - Contract total supply
  */
 export interface ApiCollectibleContractResponse {
-	description: string;
-	image_url: string;
-	name: string;
-	symbol: string;
-	total_supply: string;
+	description?: string;
+	image_url?: string;
+	name?: string;
+	symbol?: string;
+	total_supply?: string;
 }
 
 /**
@@ -78,9 +78,9 @@ export interface ApiCollectibleContractResponse {
  * @property image - Image custom image URI
  */
 export interface CollectibleInformation {
-	description: string;
-	image: string;
-	name: string;
+	description?: string;
+	image?: string;
+	name?: string;
 }
 
 /**
@@ -179,7 +179,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		const tokenURI = await this.getCollectibleTokenURI(contractAddress, tokenId);
 		const object = await handleFetch(tokenURI);
 		const image = object.hasOwnProperty('image') ? 'image' : /* istanbul ignore next */ 'image_url';
-		return { image: object[image], name: object.name, description: '' };
+		return { image: object[image], name: object.name };
 	}
 
 	/**
@@ -206,7 +206,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			return information;
 		}
 		/* istanbul ignore next */
-		return { name: '', image: '', description: '' };
+		return {};
 	}
 
 	/**
@@ -236,7 +236,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		const assetsContractController = this.context.AssetsContractController as AssetsContractController;
 		const name = await assetsContractController.getAssetName(contractAddress);
 		const symbol = await assetsContractController.getAssetSymbol(contractAddress);
-		return { name, symbol, image_url: '', description: '', total_supply: '' };
+		return { name, symbol };
 	}
 
 	/**
@@ -262,7 +262,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			return information;
 		}
 		/* istanbul ignore next */
-		return { name: '', symbol: '', image_url: '', description: '', total_supply: '' };
+		return {};
 	}
 
 	/**
@@ -289,7 +289,8 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			releaseLock();
 			return collectibles;
 		}
-		const { name, image, description } = opts ? opts : await this.getCollectibleInformation(address, tokenId);
+		const collectibleInformation = await this.getCollectibleInformation(address, tokenId);
+		const { name, image, description } = opts ? opts : collectibleInformation;
 		const newEntry: Collectible = { address, tokenId, name, image, description };
 		const newCollectibles = [...collectibles, newEntry];
 		const addressCollectibles = allCollectibles[selectedAddress];
@@ -318,9 +319,8 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			releaseLock();
 			return collectibleContracts;
 		}
-		const { name, symbol, image_url, description, total_supply } = await this.getCollectibleContractInformation(
-			address
-		);
+		const contractInformation = await this.getCollectibleContractInformation(address);
+		const { name, symbol, image_url, description, total_supply } = contractInformation;
 		const newEntry: CollectibleContract = {
 			address,
 			description,

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -234,8 +234,8 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		contractAddress: string
 	): Promise<ApiCollectibleContractResponse> {
 		const assetsContractController = this.context.AssetsContractController as AssetsContractController;
-		const name = await assetsContractController.getCollectibleContractName(contractAddress);
-		const symbol = await assetsContractController.getCollectibleContractSymbol(contractAddress);
+		const name = await assetsContractController.getAssetName(contractAddress);
+		const symbol = await assetsContractController.getAssetSymbol(contractAddress);
 		return { name, symbol, image_url: '', description: '', total_supply: '' };
 	}
 

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -182,9 +182,8 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	private async getCollectibleInformationFromTokenURI(contractAddress: string, tokenId: number) {
 		const tokenURI = await this.getCollectibleTokenURI(contractAddress, tokenId);
 		const object = await handleFetch(tokenURI);
-		const imageParam = object.hasOwnProperty('image') ? 'image' : 'image_url';
-		const collectibleImage = manageCollectibleImage(contractAddress, object[imageParam]);
-		return { image: collectibleImage, name: object.name, description: '' };
+		const image = object.hasOwnProperty('image') ? 'image' : 'image_url';
+		return { image: object[image], name: object.name, description: '' };
 	}
 
 	/**
@@ -210,7 +209,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		if (information) {
 			return information;
 		}
-		/* istanbul ignore */
+		/* istanbul ignore next */
 		return { name: '', image: '', description: '' };
 	}
 
@@ -261,7 +260,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		if (information) {
 			return information;
 		}
-		/* istanbul ignore */
+		/* istanbul ignore next */
 		return { name: '', image: '', description: '' };
 	}
 
@@ -467,6 +466,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	 * @returns - Promise resolving to the current collectible list
 	 */
 	async addCollectible(address: string, tokenId: number, opts?: CollectibleInformation) {
+		address = toChecksumAddress(address);
 		await this.addIndividualCollectible(address, tokenId, opts);
 		const { collectibleContracts } = this.state;
 		const newCollectibleContract = collectibleContracts.find(
@@ -500,6 +500,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	 * @param tokenId - Token identifier of the collectible
 	 */
 	removeCollectible(address: string, tokenId: number) {
+		address = toChecksumAddress(address);
 		this.removeIndividualCollectible(address, tokenId);
 		const { collectibles } = this.state;
 		const remainingCollectible = collectibles.find((collectible) => collectible.address === address);

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -289,8 +289,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			releaseLock();
 			return collectibles;
 		}
-		const collectibleInformation = await this.getCollectibleInformation(address, tokenId);
-		const { name, image, description } = opts ? opts : collectibleInformation;
+		const { name, image, description } = opts ? opts : await this.getCollectibleInformation(address, tokenId);
 		const newEntry: Collectible = { address, tokenId, name, image, description };
 		const newCollectibles = [...collectibles, newEntry];
 		const addressCollectibles = allCollectibles[selectedAddress];

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -156,7 +156,10 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	 * @param tokenId - The collectible identifier
 	 * @returns - Promise resolving to the current collectible name and image
 	 */
-	private async getCollectibleInformationFromApi(contractAddress: string, tokenId: number) {
+	private async getCollectibleInformationFromApi(
+		contractAddress: string,
+		tokenId: number
+	): Promise<CollectibleInformation> {
 		const tokenURI = this.getCollectibleApi(contractAddress, tokenId);
 		const { name, description, image_preview_url } = await handleFetch(tokenURI);
 		return { image: image_preview_url, name, description };
@@ -169,7 +172,10 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	 * @param tokenId - The collectible identifier
 	 * @returns - Promise resolving to the current collectible name and image
 	 */
-	private async getCollectibleInformationFromTokenURI(contractAddress: string, tokenId: number) {
+	private async getCollectibleInformationFromTokenURI(
+		contractAddress: string,
+		tokenId: number
+	): Promise<CollectibleInformation> {
 		const tokenURI = await this.getCollectibleTokenURI(contractAddress, tokenId);
 		const object = await handleFetch(tokenURI);
 		const image = object.hasOwnProperty('image') ? 'image' : /* istanbul ignore next */ 'image_url';
@@ -430,7 +436,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	 * @param decimals - Number of decimals the token uses
 	 * @returns - Current token list
 	 */
-	async addToken(address: string, symbol: string, decimals: number) {
+	async addToken(address: string, symbol: string, decimals: number): Promise<Token[]> {
 		const releaseLock = await this.mutex.acquire();
 		address = toChecksumAddress(address);
 		const { allTokens, tokens } = this.state;

--- a/src/AssetsDetectionController.test.ts
+++ b/src/AssetsDetectionController.test.ts
@@ -12,6 +12,7 @@ const DEFAULT_INTERVAL = 180000;
 const MAINNET = 'mainnet';
 const ROPSTEN = 'ropsten';
 const TOKENS = [{ address: '0xfoO', symbol: 'bar', decimals: 2 }];
+const OPEN_SEA_API = 'https://api.opensea.io/api/v1/';
 
 describe('AssetsDetectionController', () => {
 	let assetsDetection: AssetsDetectionController;
@@ -31,7 +32,7 @@ describe('AssetsDetectionController', () => {
 		new ComposableController([assets, assetsContract, assetsDetection, network, preferences]);
 
 		getOnce(
-			'https://api.opensea.io/api/v1/asset_contract/0x1d963688FE2209A98dB35C67A041524822Cf04ff',
+			OPEN_SEA_API + 'asset_contract/0x1d963688FE2209A98dB35C67A041524822Cf04ff',
 			() => ({
 				body: JSON.stringify({
 					description: 'Description',
@@ -45,7 +46,7 @@ describe('AssetsDetectionController', () => {
 		);
 
 		getOnce(
-			'https://api.opensea.io/api/v1/assets?owner=',
+			OPEN_SEA_API + 'assets?owner=',
 			() => ({
 				body: JSON.stringify({
 					assets: [

--- a/src/AssetsDetectionController.test.ts
+++ b/src/AssetsDetectionController.test.ts
@@ -92,9 +92,9 @@ describe('AssetsDetectionController', () => {
 		const clock = sandbox.useFakeTimers();
 		assetsDetection.configure({ networkType: MAINNET });
 		const detectTokens = sandbox.stub(assetsDetection, 'detectTokens').returns(null);
-		const detectCollectibleOwnership = sandbox.stub(assetsDetection, 'detectCollectibleOwnership').returns(null);
+		const detectCollectibles = sandbox.stub(assetsDetection, 'detectCollectibles').returns(null);
 		clock.tick(180001);
-		expect(detectCollectibleOwnership.called).toBe(true);
+		expect(detectCollectibles.called).toBe(true);
 		expect(detectTokens.called).toBe(true);
 	});
 
@@ -150,6 +150,7 @@ describe('AssetsDetectionController', () => {
 		expect(assets.state.collectibles).toEqual([
 			{
 				address: '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
+				description: '',
 				image: 'https://api.godsunchained.com/v0/image/380',
 				name: 'First Pheonix',
 				tokenId: 0
@@ -181,6 +182,7 @@ describe('AssetsDetectionController', () => {
 		expect(assets.state.collectibles).toEqual([
 			{
 				address: '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d',
+				description: '',
 				image: 'https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/411073.svg',
 				name: 'TestName',
 				tokenId: 411073

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -13,14 +13,22 @@ const DEFAULT_INTERVAL = 180000;
 const MAINNET = 'mainnet';
 
 /**
- * @type CollectibleEntry
+ * @type ApiCollectibleResponse
  *
- * Collectible minimal representation expected on collectibles api
+ * Collectible object coming from OpenSea api
  *
- * @property id - Collectible identifier
+ * @property token_id - The collectible identifier
+ * @property image_preview_url - URI of collectible image associated with this collectible
+ * @property name - The collectible name
+ * @property description - The collectible description
+ * @property assetContract - The collectible contract basic information, in this case the address
  */
-export interface CollectibleEntry {
-	id: number;
+export interface ApiCollectibleResponse {
+	token_id: string;
+	image_preview_url: string;
+	name: string;
+	description: string;
+	asset_contract: { [address: string]: string };
 }
 
 /**
@@ -38,25 +46,6 @@ export interface AssetsDetectionConfig extends BaseConfig {
 	networkType: NetworkType;
 	selectedAddress: string;
 	tokens: Token[];
-}
-
-/**
- * @type ApiCollectibleResponse
- *
- * Collectible object coming from OpenSea api
- *
- * @property token_id - The collectible identifier
- * @property image_preview_url - URI of collectible image associated with this collectible
- * @property name - The collectible name
- * @property description - The collectible description
- * @property assetContract - The collectible contract basic information, in this case the address
- */
-export interface ApiCollectibleResponse {
-	token_id: string;
-	image_preview_url: string;
-	name: string;
-	description: string;
-	asset_contract: { [address: string]: string };
 }
 
 /**

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -84,7 +84,6 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 
 	private async getCollectibleContract(contractAddress: string) {
 		const api = this.getAssetContractApi(contractAddress);
-		console.log('api', api);
 		const response = await fetch(api);
 		const collectibleContractObject = await response.json();
 		const collectibleContractInformation = collectibleContractObject;

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -138,6 +138,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 	 * Detect assets owned by current account on mainnet
 	 */
 	async detectAssets() {
+		/* istanbul ignore if */
 		if (!this.isMainnet()) {
 			return;
 		}
@@ -149,6 +150,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 	 * Triggers asset ERC20 token auto detection for each contract address in contract metadata on mainnet
 	 */
 	async detectTokens() {
+		/* istanbul ignore if */
 		if (!this.isMainnet()) {
 			return;
 		}
@@ -179,12 +181,13 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 	 * Triggers asset ERC721 token auto detection suing OpenSea on mainnet
 	 */
 	async detectCollectibles() {
+		/* istanbul ignore if */
 		if (!this.isMainnet()) {
 			return;
 		}
 		const assetsController = this.context.AssetsController as AssetsController;
 		const collectibles = await this.getOwnerCollectibles();
-		await collectibles.reduce(async (list: string[], collectible: ApiCollectibleResponse) => {
+		const addCollectiblesPromises = collectibles.map(async (collectible: ApiCollectibleResponse) => {
 			const {
 				token_id,
 				image_preview_url,
@@ -197,11 +200,8 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 				image: image_preview_url,
 				name
 			});
-			if (!list.includes(address)) {
-				list.push(address);
-			}
-			return list;
-		}, []);
+		});
+		await Promise.all(addCollectiblesPromises);
 	}
 
 	/**

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -69,10 +69,6 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 		return `https://api.opensea.io/api/v1/assets?owner=${address}`;
 	}
 
-	private getAssetContractApi(contractAddress: string) {
-		return `https://api.opensea.io/api/v1/asset_contract/${contractAddress}`;
-	}
-
 	private async getOwnerCollectibles() {
 		const { selectedAddress } = this.config;
 		const api = this.getOwnerCollectiblesApi(selectedAddress);
@@ -80,14 +76,6 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 		const collectiblesArray = await response.json();
 		const collectibles = collectiblesArray.assets;
 		return collectibles;
-	}
-
-	private async getCollectibleContract(contractAddress: string) {
-		const api = this.getAssetContractApi(contractAddress);
-		const response = await fetch(api);
-		const collectibleContractObject = await response.json();
-		const collectibleContractInformation = collectibleContractObject;
-		return collectibleContractInformation;
 	}
 
 	/**
@@ -310,9 +298,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 			[]
 		);
 		collectibleContractAddresses.map(async (address: string) => {
-			const information = await this.getCollectibleContract(address);
-			const { name, symbol, image_url, description, total_supply } = information;
-			assetsController.addCollectibleContract(address, name, symbol, image_url, description, total_supply);
+			assetsController.addCollectibleContract(address);
 		});
 	}
 

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -184,30 +184,24 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 		}
 		const assetsController = this.context.AssetsController as AssetsController;
 		const collectibles = await this.getOwnerCollectibles();
-		const collectibleContractAddresses = await collectibles.reduce(
-			async (list: string[], collectible: ApiCollectibleResponse) => {
-				const {
-					token_id,
-					image_preview_url,
-					name,
-					description,
-					asset_contract: { address }
-				} = collectible;
-				await assetsController.addCollectible(address, Number(token_id), {
-					description,
-					image: image_preview_url,
-					name
-				});
-				if (!list.includes(address)) {
-					list.push(address);
-				}
-				return list;
-			},
-			[]
-		);
-		collectibleContractAddresses.map(async (address: string) => {
-			assetsController.addCollectibleContract(address);
-		});
+		await collectibles.reduce(async (list: string[], collectible: ApiCollectibleResponse) => {
+			const {
+				token_id,
+				image_preview_url,
+				name,
+				description,
+				asset_contract: { address }
+			} = collectible;
+			await assetsController.addCollectible(address, Number(token_id), {
+				description,
+				image: image_preview_url,
+				name
+			});
+			if (!list.includes(address)) {
+				list.push(address);
+			}
+			return list;
+		}, []);
 	}
 
 	/**

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from './BaseController';
-import AssetsController, { Collectible } from './AssetsController';
+import AssetsController from './AssetsController';
 import NetworkController from './NetworkController';
 import PreferencesController from './PreferencesController';
 import AssetsContractController from './AssetsContractController';
@@ -40,12 +40,23 @@ export interface AssetsDetectionConfig extends BaseConfig {
 	tokens: Token[];
 }
 
+/**
+ * @type ApiCollectibleResponse
+ *
+ * Collectible object coming from OpenSea api
+ *
+ * @property token_id - The collectible identifier
+ * @property image_preview_url - URI of collectible image associated with this collectible
+ * @property name - The collectible name
+ * @property description - The collectible description
+ * @property assetContract - The collectible contract basic information, in this case the address
+ */
 export interface ApiCollectibleResponse {
 	token_id: string;
-	image_url: string;
+	image_preview_url: string;
 	name: string;
 	description: string;
-	assetContract: { [address: string]: string };
+	asset_contract: { [address: string]: string };
 }
 
 /**
@@ -268,12 +279,12 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 		collectibles.map((collectible: ApiCollectibleResponse) => {
 			const {
 				token_id,
-				image_url,
+				image_preview_url,
 				name,
 				description,
-				assetContract: { address }
+				asset_contract: { address }
 			} = collectible;
-			assetsController.addCollectible(address, Number(token_id), { name, description, image: image_url });
+			assetsController.addCollectible(address, Number(token_id), { name, description, image: image_preview_url });
 		});
 	}
 

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -23,9 +23,10 @@ describe('ComposableController', () => {
 			AddressBookController: { addressBook: [] },
 			AssetsContractController: {},
 			AssetsController: {
-				allCollectibleContracts: [],
+				allCollectibleContracts: {},
 				allCollectibles: {},
 				allTokens: {},
+				collectibleContracts: [],
 				collectibles: [],
 				tokens: []
 			},
@@ -62,9 +63,10 @@ describe('ComposableController', () => {
 		]);
 		expect(controller.flatState).toEqual({
 			addressBook: [],
-			allCollectibleContracts: [],
+			allCollectibleContracts: {},
 			allCollectibles: {},
 			allTokens: {},
+			collectibleContracts: [],
 			collectibles: [],
 			contractExchangeRates: {},
 			conversionDate: 0,
@@ -98,9 +100,10 @@ describe('ComposableController', () => {
 		addressContext.set('1337', 'foo');
 		expect(controller.flatState).toEqual({
 			addressBook: [{ address: '1337', name: 'foo' }],
-			allCollectibleContracts: [],
+			allCollectibleContracts: {},
 			allCollectibles: {},
 			allTokens: {},
+			collectibleContracts: [],
 			collectibles: [],
 			contractExchangeRates: {},
 			conversionDate: 0,

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -28,14 +28,6 @@ describe('util', () => {
 		expect(util.hexToBN('0x1337').toNumber()).toBe(4919);
 	});
 
-	describe('manageCollectibleImage', () => {
-		const address1 = '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab';
-		const address2 = '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ac';
-		const image = 'https://api.godsunchained.com/v0/image/351?format=card&quality=diamond';
-		expect(util.manageCollectibleImage(address1, image)).toEqual('https://api.godsunchained.com/v0/image/351');
-		expect(util.manageCollectibleImage(address2, image)).toEqual(image);
-	});
-
 	it('normalizeTransaction', () => {
 		const normalized = util.normalizeTransaction({
 			data: 'data',

--- a/src/util.ts
+++ b/src/util.ts
@@ -124,6 +124,18 @@ export async function safelyExecute(operation: () => Promise<any>) {
 }
 
 /**
+ * Execute fetch and return object response
+ *
+ * @param request - Request information
+ * @returns - Promise resolving to the result object of fetch
+ */
+export async function handleFetch(request: string) {
+	const response = await fetch(request);
+	const object = await response.json();
+	return object;
+}
+
+/**
  * Validates a Transaction object for required properties and throws in
  * the event of any validation error.
  *
@@ -261,6 +273,7 @@ export default {
 	BNToHex,
 	fractionBN,
 	getBuyURL,
+	handleFetch,
 	hexToBN,
 	hexToText,
 	manageCollectibleImage,

--- a/src/util.ts
+++ b/src/util.ts
@@ -251,24 +251,6 @@ export function validateTypedSignMessageDataV3(messageData: TypedMessageParams, 
 	}
 }
 
-/**
- * Modifies collectible images URI in case is necessary
- *
- * @param address - Collectible address
- * @param image - Initial image URI given by collectible tokenURI
- * @returns - Modified image URI
- */
-export function manageCollectibleImage(address: string, image: string) {
-	const GODSADDRESS = '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab';
-	let collectibleImage;
-	if (address === GODSADDRESS) {
-		collectibleImage = image.split('?')[0];
-	} else {
-		collectibleImage = image;
-	}
-	return collectibleImage;
-}
-
 export default {
 	BNToHex,
 	fractionBN,
@@ -276,7 +258,6 @@ export default {
 	handleFetch,
 	hexToBN,
 	hexToText,
-	manageCollectibleImage,
 	normalizeTransaction,
 	safelyExecute,
 	validateTransaction,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"strict": true,
-		"target": "es6"
+		"target": "es6",
+		"lib": ["es6", "dom", "es2017"]
 	},
 	"typedocOptions": {
 		"exclude": "**/*.test.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"strict": true,
-		"target": "es6",
-		"lib": ["es6", "dom", "es2017"]
+		"target": "es6"
 	},
 	"typedocOptions": {
 		"exclude": "**/*.test.ts",


### PR DESCRIPTION
This PR introduces several changes in the way collectibles are handled.

1. Auto-detection of collectibles is made completely using OpenSea API.
2. A new object called `CollectibleContract` was created to handle all collectible contract information as name, image, description, total supply, address and symbol. Maintaining the responsibility of the object `Collectible` to handle individual collectible information.
3. Added two methods to interact with collectible contracts, in order to get name and symbol. This is important for users adding collectibles in test nets.
4. If users add collectibles that are not in OpenSea API (probably using test nets) and those contracts respect `ERC721 Metatada Interface`, those manually added collectibles are still going to fetch name and image to be displayed.
5. Auto-detection using eth-contract-metadata related code was deleted.
6. Add convenient contract methods to get assets name and symbol, and token decimals.