### PR TITLE
return last incoming tx block number for current network ONLY

### DIFF
--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -553,7 +553,11 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 			let latestIncomingTxBlockNumber: string | undefined;
 			allTxs.forEach((tx) => {
 				/* istanbul ignore next */
-				if (tx.transaction.to && tx.transaction.to.toLowerCase() === address.toLowerCase()) {
+				if (
+					tx.networkID === currentNetworkID &&
+					tx.transaction.to &&
+					tx.transaction.to.toLowerCase() === address.toLowerCase()
+				) {
 					if (
 						tx.blockNumber &&
 						(!latestIncomingTxBlockNumber ||


### PR DESCRIPTION
I forgot to filter for the network and as a result it was always returning the last incoming tx block from mainnet (which has the highest block number)