### PR TITLE
Performance updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "node"
+node_js: "8"
 install:
 - travis_retry npm install -g codecov
 - travis_retry npm install

--- a/src/AccountTrackerController.ts
+++ b/src/AccountTrackerController.ts
@@ -124,6 +124,7 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
 			await safelyExecute(async () => {
 				const balance = await this.ethjsQuery.getBalance(address);
 				accounts[address] = { balance: BNToHex(balance) };
+				this.update({ accounts: { ...accounts } });
 			});
 		}
 		/* tslint:disable-next-line */

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -428,7 +428,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	constructor(config?: Partial<BaseConfig>, state?: Partial<AssetsState>) {
 		super(config, state);
 		this.defaultConfig = {
-			networkType: 'ropsten',
+			networkType: 'mainnet',
 			selectedAddress: ''
 		};
 		this.defaultState = {

--- a/src/AssetsDetectionController.test.ts
+++ b/src/AssetsDetectionController.test.ts
@@ -46,7 +46,7 @@ describe('AssetsDetectionController', () => {
 		);
 
 		getOnce(
-			OPEN_SEA_API + 'assets?owner=',
+			OPEN_SEA_API + 'assets?owner=0x1',
 			() => ({
 				body: JSON.stringify({
 					assets: [
@@ -215,24 +215,24 @@ describe('AssetsDetectionController', () => {
 	});
 
 	it('should detect and add collectibles correctly', async () => {
-		assetsDetection.configure({ networkType: MAINNET });
+		assetsDetection.configure({ networkType: MAINNET, selectedAddress: '0x1' });
 		await assetsDetection.detectCollectibles();
+		console.log('RECEIVED', assets.state.collectibles);
 		expect(assets.state.collectibles).toEqual([
 			{
-				address: '0x1d963688FE2209A98dB35C67A041524822Cf04ff',
-				description: 'Description 2577',
-				image: 'image/2577.png',
-				name: 'ID 2577',
-				tokenId: 2577
-			},
-			{
-				address: '0x1d963688FE2209A98dB35C67A041524822Cf04ff',
+				address: '0x1D963688FE2209A98db35c67A041524822cf04Hh',
 				description: 'Description 2574',
 				image: 'image/2574.png',
 				name: 'ID 2574',
 				tokenId: 2574
 			}
 		]);
+	});
+
+	it('should not detect and add collectibles if there is no selectedAddress', async () => {
+		assetsDetection.configure({ networkType: MAINNET });
+		await assetsDetection.detectCollectibles();
+		expect(assets.state.collectibles).toEqual([]);
 	});
 
 	it('should not add collectible if collectible or collectible contract has no information to display', async () => {
@@ -363,7 +363,7 @@ describe('AssetsDetectionController', () => {
 	});
 
 	it('should detect tokens correctly', async () => {
-		assetsDetection.configure({ networkType: MAINNET });
+		assetsDetection.configure({ networkType: MAINNET, selectedAddress: '0x1' });
 		sandbox
 			.stub(assetsContract, 'getBalancesInSingleCall')
 			.returns({ '0x6810e776880C02933D47DB1b9fc05908e5386b96': new BN(1) });
@@ -375,6 +375,15 @@ describe('AssetsDetectionController', () => {
 				symbol: 'GNO'
 			}
 		]);
+	});
+
+	it('should not detect tokens if there is no selectedAddress set', async () => {
+		assetsDetection.configure({ networkType: MAINNET });
+		sandbox
+			.stub(assetsContract, 'getBalancesInSingleCall')
+			.returns({ '0x6810e776880C02933D47DB1b9fc05908e5386b96': new BN(1) });
+		await assetsDetection.detectTokens();
+		expect(assets.state.tokens).toEqual([]);
 	});
 
 	it('should subscribe to new sibling detecting assets when account changes', async () => {

--- a/src/AssetsDetectionController.test.ts
+++ b/src/AssetsDetectionController.test.ts
@@ -150,7 +150,7 @@ describe('AssetsDetectionController', () => {
 	it('should set default config', () => {
 		expect(assetsDetection.config).toEqual({
 			interval: DEFAULT_INTERVAL,
-			networkType: 'ropsten',
+			networkType: 'mainnet',
 			selectedAddress: '',
 			tokens: []
 		});

--- a/src/AssetsDetectionController.test.ts
+++ b/src/AssetsDetectionController.test.ts
@@ -217,7 +217,6 @@ describe('AssetsDetectionController', () => {
 	it('should detect and add collectibles correctly', async () => {
 		assetsDetection.configure({ networkType: MAINNET, selectedAddress: '0x1' });
 		await assetsDetection.detectCollectibles();
-		console.log('RECEIVED', assets.state.collectibles);
 		expect(assets.state.collectibles).toEqual([
 			{
 				address: '0x1D963688FE2209A98db35c67A041524822cf04Hh',

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -92,7 +92,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 		super(config, state);
 		this.defaultConfig = {
 			interval: DEFAULT_INTERVAL,
-			networkType: 'ropsten',
+			networkType: 'mainnet',
 			selectedAddress: '',
 			tokens: []
 		};

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -154,7 +154,10 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 
 		const assetsContractController = this.context.AssetsContractController as AssetsContractController;
 		const { selectedAddress } = this.config;
-
+		/* istanbul ignore else */
+		if (!selectedAddress) {
+			return;
+		}
 		const balances = await assetsContractController.getBalancesInSingleCall(selectedAddress, tokensToDetect);
 		const assetsController = this.context.AssetsController as AssetsController;
 		for (const tokenAddress in balances) {
@@ -172,6 +175,11 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 	async detectCollectibles() {
 		/* istanbul ignore if */
 		if (!this.isMainnet()) {
+			return;
+		}
+		const { selectedAddress } = this.config;
+		/* istanbul ignore else */
+		if (!selectedAddress) {
 			return;
 		}
 		const assetsController = this.context.AssetsController as AssetsController;

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -38,7 +38,7 @@ describe('ComposableController', () => {
 			},
 			NetworkController: {
 				network: 'loading',
-				provider: { type: 'rinkeby' }
+				provider: { type: 'mainnet' }
 			},
 			PreferencesController: {
 				featureFlags: {},
@@ -78,7 +78,7 @@ describe('ComposableController', () => {
 			lostIdentities: {},
 			nativeCurrency: 'eth',
 			network: 'loading',
-			provider: { type: 'rinkeby' },
+			provider: { type: 'mainnet' },
 			selectedAddress: '',
 			tokens: []
 		});
@@ -115,7 +115,7 @@ describe('ComposableController', () => {
 			lostIdentities: {},
 			nativeCurrency: 'eth',
 			network: 'loading',
-			provider: { type: 'rinkeby' },
+			provider: { type: 'mainnet' },
 			selectedAddress: '',
 			tokens: []
 		});

--- a/src/NetworkController.test.ts
+++ b/src/NetworkController.test.ts
@@ -10,7 +10,7 @@ describe('NetworkController', () => {
 		expect(controller.state).toEqual({
 			network: 'loading',
 			provider: {
-				type: 'rinkeby'
+				type: 'mainnet'
 			}
 		});
 	});
@@ -74,15 +74,6 @@ describe('NetworkController', () => {
 		const controller = new NetworkController();
 		controller.setProviderType('localhost');
 		expect(controller.state.provider.type).toBe('localhost');
-	});
-
-	it('should verify the network on a new block', () => {
-		const controller = new NetworkController(undefined, { network: 'loading' });
-		controller.lookupNetwork();
-		controller.providerConfig = {} as ProviderConfig;
-		controller.lookupNetwork = stub();
-		controller.provider.emit('block', {});
-		expect((controller.lookupNetwork as any).called).toBe(true);
 	});
 
 	it('should verify the network on an error', async () => {

--- a/src/NetworkController.ts
+++ b/src/NetworkController.ts
@@ -84,7 +84,6 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 	}
 
 	private registerProvider() {
-		this.provider.on('block', this.verifyNetwork.bind(this));
 		this.provider.on('error', this.verifyNetwork.bind(this));
 		this.ethQuery = new EthQuery(this.provider);
 	}
@@ -146,7 +145,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 		super(config, state);
 		this.defaultState = {
 			network: 'loading',
-			provider: { type: 'rinkeby' }
+			provider: { type: 'mainnet' }
 		};
 		this.initialize();
 	}

--- a/src/NetworkController.ts
+++ b/src/NetworkController.ts
@@ -97,7 +97,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 				dataSubprovider: infuraSubprovider,
 				engineParams: {
 					blockTrackerProvider: infuraProvider,
-					pollingInterval: 8000
+					pollingInterval: 12000
 				}
 			}
 		};
@@ -108,7 +108,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 		const config = {
 			...this.internalProviderConfig,
 			...{
-				engineParams: { pollingInterval: 8000 },
+				engineParams: { pollingInterval: 12000 },
 				rpcUrl: rpcTarget
 			}
 		};


### PR DESCRIPTION
I've spent some time on the app side trying to identify the bottlenecks and this is the stuff I found:

- Change network controller polling from 8 to 12 seconds (Based on https://etherscan.io/chart/blocktime blocktime was never below 13) so by changing this we're doing 30% less requests.

- Update account balance in state right after each individual request. The state wasn't updating immediately causing a noticeable delay in the UI.

- Make "mainnet" the default network. This is how every client is supposed to initialize by default so we're avoiding extra requests to another network on startup.

- Prevent asset detection (tokens & collectibles) if the selectedAddress wasn't set. 
 `provider` and `selectedAddress` are two independent config settings and we should only try to detect assets once we have both.

- Don't verify network on new block - I couldn't find a good answer about why we should be calling infura with net_version right after getting a new block.  This was doubling the amount of requests to infura on our end. 

Unrelated:  GABA is using the latest version of node for travisCI and [jest broke in node 11.11.0](https://github.com/facebook/jest/issues/8069), so I had to downgrade.  Since we're using the latest stable version of node 8 in the app and extension, I've set it up like that here too.