### PR TITLE
Transaction to smart contract

### DIFF
--- a/src/TransactionController.test.ts
+++ b/src/TransactionController.test.ts
@@ -107,7 +107,7 @@ const MOCK_FETCH_TX_HISTORY_DATA_OK = {
 			gasPrice: '20000000000',
 			gasUsed: '21000',
 			hash: '0x342e9d73e10004af41d04973339fc7219dbadcbb5629730cfe65e9f9cb15ff91',
-			input: '0x',
+			input: '0x1',
 			isError: '0',
 			nonce: '1',
 			timeStamp: '1543596356',

--- a/src/TransactionController.test.ts
+++ b/src/TransactionController.test.ts
@@ -107,7 +107,7 @@ const MOCK_FETCH_TX_HISTORY_DATA_OK = {
 			gasPrice: '20000000000',
 			gasUsed: '21000',
 			hash: '0x342e9d73e10004af41d04973339fc7219dbadcbb5629730cfe65e9f9cb15ff91',
-			input: '0x1',
+			input: '0x',
 			isError: '0',
 			nonce: '1',
 			timeStamp: '1543596356',

--- a/src/TransactionController.test.ts
+++ b/src/TransactionController.test.ts
@@ -96,6 +96,24 @@ const MOCK_FETCH_TX_HISTORY_DATA_OK = {
 			transactionIndex: '12',
 			txreceipt_status: '1',
 			value: '50000000000000000'
+		},
+		{
+			blockNumber: '4535105',
+			confirmations: '4',
+			contractAddress: '',
+			cumulativeGasUsed: '693910',
+			from: '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207',
+			gas: '335208',
+			gasPrice: '20000000000',
+			gasUsed: '21000',
+			hash: '0x342e9d73e10004af41d04973339fc7219dbadcbb5629730cfe65e9f9cb15ff91',
+			input: '0x',
+			isError: '0',
+			nonce: '1',
+			timeStamp: '1543596356',
+			transactionIndex: '13',
+			txreceipt_status: '1',
+			value: '50000000000000000'
 		}
 	],
 	status: '1'
@@ -373,7 +391,7 @@ describe('TransactionController', () => {
 
 		const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
 		const latestBlock = await controller.fetchAll(from);
-		expect(controller.state.transactions.length).toBe(2);
+		expect(controller.state.transactions.length).toBe(3);
 		expect(latestBlock).toBe('4535101');
 		expect(controller.state.transactions[0].transaction.to).toBe(from);
 	});
@@ -387,7 +405,6 @@ describe('TransactionController', () => {
 		} as any;
 		controller.onComposed();
 		expect(controller.state.transactions.length).toBe(0);
-
 		const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
 		const result = await controller.fetchAll(from);
 		expect(controller.state.transactions.length).toBe(0);

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -64,7 +64,6 @@ export interface Transaction {
  * @property rawTransaction - Hex representation of the underlying transaction
  * @property status - String status of this transaction
  * @property toSmartContract - Whether transaction receipt is a smart contract
- * @property status - String status of this transaction
  * @property transaction - Underlying Transaction object
  * @property transactionHash - Hash of a successful transaction
  * @property blockNumber - Number of the block where the transaction has been included

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -578,7 +578,8 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 				}
 				/* istanbul ignore else */
 				if (tx.toSmartContract === undefined) {
-					if (tx.transaction.to) {
+					// If not `to` is a contract deploy, if not `data` is send eth
+					if (tx.transaction.to || !tx.transaction.data || tx.transaction.data === '0x') {
 						const code = await this.query('getCode', [tx.transaction.to]);
 						tx.toSmartContract = isSmartContractCode(code);
 					} else {

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -577,11 +577,14 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 						latestIncomingTxBlockNumber = tx.blockNumber;
 					}
 				}
-				if (tx.toSmartContract === undefined && tx.transaction.to) {
-					const code = await this.query('getCode', [tx.transaction.to]);
-					tx.toSmartContract = isSmartContractCode(code);
-				} else if (!tx.transaction.to) {
-					tx.toSmartContract = false;
+				/* istanbul ignore else */
+				if (tx.toSmartContract === undefined) {
+					if (tx.transaction.to) {
+						const code = await this.query('getCode', [tx.transaction.to]);
+						tx.toSmartContract = isSmartContractCode(code);
+					} else {
+						tx.toSmartContract = false;
+					}
 				}
 			});
 

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -579,7 +579,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 				/* istanbul ignore else */
 				if (tx.toSmartContract === undefined) {
 					// If not `to` is a contract deploy, if not `data` is send eth
-					if (tx.transaction.to || !tx.transaction.data || tx.transaction.data === '0x') {
+					if (tx.transaction.to || !tx.transaction.data || tx.transaction.data !== '0x') {
 						const code = await this.query('getCode', [tx.transaction.to]);
 						tx.toSmartContract = isSmartContractCode(code);
 					} else {

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -63,7 +63,7 @@ export interface Transaction {
  * @property origin - Origin this transaction was sent from
  * @property rawTransaction - Hex representation of the underlying transaction
  * @property status - String status of this transaction
- * @property toSmartContract - Whether transaction receipt is a smart contract
+ * @property toSmartContract - Whether transaction recipient is a smart contract
  * @property transaction - Underlying Transaction object
  * @property transactionHash - Hash of a successful transaction
  * @property blockNumber - Number of the block where the transaction has been included

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -341,5 +341,16 @@ describe('util', () => {
 				)
 			).not.toThrow();
 		});
+
+		it('should not throw if data is correct', () => {
+			const toSmartContract1 = util.isSmartContractCode('');
+			const toSmartContract2 = util.isSmartContractCode('0x');
+			const toSmartContract3 = util.isSmartContractCode('0x0');
+			const toSmartContract4 = util.isSmartContractCode('0x01234');
+			expect(toSmartContract1).toBe(false);
+			expect(toSmartContract2).toBe(false);
+			expect(toSmartContract3).toBe(false);
+			expect(toSmartContract4).toBe(true);
+		});
 	});
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -251,6 +251,20 @@ export function validateTypedSignMessageDataV3(messageData: TypedMessageParams, 
 	}
 }
 
+/**
+ * Returns wether the given code corresponds to a smart contract
+ *
+ * @returns {string} - Corresponding code to review
+ */
+export function isSmartContractCode(code: string) {
+	if (!code) {
+		return false;
+	}
+	// Geth will return '0x', and ganache-core v2.2.1 will return '0x0'
+	const smartContractCode = code !== '0x' && code !== '0x0';
+	return smartContractCode;
+}
+
 export default {
 	BNToHex,
 	fractionBN,
@@ -258,6 +272,7 @@ export default {
 	handleFetch,
 	hexToBN,
 	hexToText,
+	isSmartContractCode,
 	normalizeTransaction,
 	safelyExecute,
 	validateTransaction,

--- a/src/util.ts
+++ b/src/util.ts
@@ -257,6 +257,7 @@ export function validateTypedSignMessageDataV3(messageData: TypedMessageParams, 
  * @returns {string} - Corresponding code to review
  */
 export function isSmartContractCode(code: string) {
+	/* istanbul ignore if */
 	if (!code) {
 		return false;
 	}


### PR DESCRIPTION
This PR adds `toSmartContract` attribute to `TransactionMeta` object, it shows whether the transaction was sent to a smart contract or not, request that is being done only once when the tx is fetched. 
This avoids requesting this information (hitting infura) each time we render a transaction or having the audit issue caching this information.