### PR TITLE
Fix polling

### DIFF
--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -101,12 +101,12 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 	}
 
 	/**
-	 * starts a new polling interval
+	 * Starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to auto detect assets
 	 */
-	async poll(interval?: number) {
-		this.config.interval = interval || this.config.interval;
+	async poll(interval?: number): Promise<void> {
+		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.detectAssets());
 		this.handle = setTimeout(() => {

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -97,18 +97,21 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 			tokens: []
 		};
 		this.initialize();
+		this.poll();
 	}
 
 	/**
-	 * Sets a new polling interval
+	 * starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to auto detect assets
 	 */
-	set interval(interval: number) {
-		this.handle && clearInterval(this.handle);
-		this.handle = setInterval(() => {
-			safelyExecute(() => this.detectAssets());
-		}, interval);
+	async poll(interval?: number) {
+		this.config.interval = interval || this.config.interval;
+		this.handle && clearTimeout(this.handle);
+		await safelyExecute(() => this.detectAssets());
+		this.handle = setTimeout(() => {
+			this.poll(this.config.interval);
+		}, this.config.interval);
 	}
 
 	/**

--- a/src/CurrencyRateController.ts
+++ b/src/CurrencyRateController.ts
@@ -101,12 +101,12 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	}
 
 	/**
-	 * starts a new polling interval
+	 * Starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new exchange rate
 	 */
-	async poll(interval?: number) {
-		this.config.interval = interval || this.config.interval;
+	async poll(interval?: number): Promise<void> {
+		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateExchangeRate());
 		this.handle = setTimeout(() => {

--- a/src/CurrencyRateController.ts
+++ b/src/CurrencyRateController.ts
@@ -65,6 +65,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 		super(config, state);
 		this.defaultConfig = {
 			currentCurrency: 'usd',
+			disabled: true,
 			interval: 180000,
 			nativeCurrency: 'eth'
 		};
@@ -75,6 +76,8 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 			nativeCurrency: this.defaultConfig.nativeCurrency
 		};
 		this.initialize();
+		this.disabled = false;
+		this.poll();
 	}
 
 	/**
@@ -98,16 +101,17 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	}
 
 	/**
-	 * Sets a new polling interval
+	 * starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new exchange rate
 	 */
-	set interval(interval: number) {
-		this.handle && clearInterval(this.handle);
-		safelyExecute(() => this.updateExchangeRate());
-		this.handle = setInterval(() => {
-			safelyExecute(() => this.updateExchangeRate());
-		}, interval);
+	async poll(interval?: number) {
+		this.config.interval = interval || this.config.interval;
+		this.handle && clearTimeout(this.handle);
+		await safelyExecute(() => this.updateExchangeRate());
+		this.handle = setTimeout(() => {
+			this.poll(this.config.interval);
+		}, this.config.interval);
 	}
 
 	/**

--- a/src/NetworkStatusController.ts
+++ b/src/NetworkStatusController.ts
@@ -1,5 +1,6 @@
 import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from './BaseController';
+import { safelyExecute } from './util';
 
 /**
  * Network status code string
@@ -73,19 +74,21 @@ export class NetworkStatusController extends BaseController<NetworkStatusConfig,
 			}
 		};
 		this.initialize();
+		this.poll();
 	}
 
 	/**
-	 * Sets a new polling interval
+	 * starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch network status
 	 */
-	set interval(interval: number) {
-		this.updateNetworkStatuses();
-		this.handle && clearInterval(this.handle);
-		this.handle = setInterval(() => {
-			this.updateNetworkStatuses();
-		}, interval);
+	async poll(interval?: number) {
+		this.config.interval = interval || this.config.interval;
+		this.handle && clearTimeout(this.handle);
+		await safelyExecute(() => this.updateNetworkStatuses());
+		this.handle = setTimeout(() => {
+			this.poll(this.config.interval);
+		}, this.config.interval);
 	}
 
 	/**

--- a/src/NetworkStatusController.ts
+++ b/src/NetworkStatusController.ts
@@ -78,12 +78,12 @@ export class NetworkStatusController extends BaseController<NetworkStatusConfig,
 	}
 
 	/**
-	 * starts a new polling interval
+	 * Starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch network status
 	 */
-	async poll(interval?: number) {
-		this.config.interval = interval || this.config.interval;
+	async poll(interval?: number): Promise<void> {
+		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateNetworkStatuses());
 		this.handle = setTimeout(() => {

--- a/src/PhishingController.ts
+++ b/src/PhishingController.ts
@@ -75,12 +75,12 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 	}
 
 	/**
-	 * starts a new polling interval
+	 * Starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new approval lists
 	 */
-	async poll(interval?: number) {
-		this.config.interval = interval || this.config.interval;
+	async poll(interval?: number): Promise<void> {
+		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updatePhishingLists());
 		this.handle = setTimeout(() => {

--- a/src/PhishingController.ts
+++ b/src/PhishingController.ts
@@ -71,19 +71,21 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 		this.defaultState = { phishing: DEFAULT_PHISHING_RESPONSE };
 		this.detector = new PhishingDetector(this.defaultState.phishing);
 		this.initialize();
+		this.poll();
 	}
 
 	/**
-	 * Sets a new polling interval
+	 * starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new approval lists
 	 */
-	set interval(interval: number) {
-		this.handle && clearInterval(this.handle);
-		this.updatePhishingLists();
-		this.handle = setInterval(() => {
-			this.updatePhishingLists();
-		}, interval);
+	async poll(interval?: number) {
+		this.config.interval = interval || this.config.interval;
+		this.handle && clearTimeout(this.handle);
+		await safelyExecute(() => this.updatePhishingLists());
+		this.handle = setTimeout(() => {
+			this.poll(this.config.interval);
+		}, this.config.interval);
 	}
 
 	/**
@@ -105,12 +107,11 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 		if (this.disabled) {
 			return;
 		}
-		return safelyExecute(async () => {
-			const response = await fetch('https://api.infura.io/v2/blacklist');
-			const phishing = await response.json();
-			this.detector = new PhishingDetector(phishing);
-			phishing && this.update({ phishing });
-		});
+
+		const response = await fetch('https://api.infura.io/v2/blacklist');
+		const phishing = await response.json();
+		this.detector = new PhishingDetector(phishing);
+		phishing && this.update({ phishing });
 	}
 }
 

--- a/src/ShapeShiftController.ts
+++ b/src/ShapeShiftController.ts
@@ -95,19 +95,21 @@ export class ShapeShiftController extends BaseController<ShapeShiftConfig, Shape
 		this.defaultConfig = { interval: 3000 };
 		this.defaultState = { shapeShiftTxList: [] };
 		this.initialize();
+		this.poll();
 	}
 
 	/**
-	 * Sets a new polling interval
+	 * starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new ShapeShift transactions
 	 */
-	set interval(interval: number) {
-		this.handle && clearInterval(this.handle);
-		this.updateTransactionList();
-		this.handle = setInterval(() => {
-			this.updateTransactionList();
-		}, interval);
+	async poll(interval?: number) {
+		this.config.interval = interval || this.config.interval;
+		this.handle && clearTimeout(this.handle);
+		await safelyExecute(() => this.updateTransactionList());
+		this.handle = setTimeout(() => {
+			this.poll(this.config.interval);
+		}, this.config.interval);
 	}
 
 	/**

--- a/src/ShapeShiftController.ts
+++ b/src/ShapeShiftController.ts
@@ -99,12 +99,12 @@ export class ShapeShiftController extends BaseController<ShapeShiftConfig, Shape
 	}
 
 	/**
-	 * starts a new polling interval
+	 * Starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new ShapeShift transactions
 	 */
-	async poll(interval?: number) {
-		this.config.interval = interval || this.config.interval;
+	async poll(interval?: number): Promise<void> {
+		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateTransactionList());
 		this.handle = setTimeout(() => {

--- a/src/TokenBalancesController.test.ts
+++ b/src/TokenBalancesController.test.ts
@@ -34,20 +34,42 @@ describe('TokenBalancesController', () => {
 		});
 	});
 
-	it('should poll on correct interval', () => {
-		const func = sandbox.stub(global, 'setInterval');
-		/* tslint:disable-next-line:no-unused-expression */
-		new TokenBalancesController({ interval: 1337 });
-		expect(func.getCall(0).args[1]).toBe(1337);
-		func.restore();
+	it('should poll and update balances in the right interval', () => {
+		return new Promise((resolve) => {
+			const mock = stub(TokenBalancesController.prototype, 'updateBalances');
+			// tslint:disable-next-line: no-unused-expression
+			new TokenBalancesController({ interval: 10 });
+			expect(mock.called).toBe(true);
+			expect(mock.calledTwice).toBe(false);
+			setTimeout(() => {
+				expect(mock.calledTwice).toBe(true);
+				mock.restore();
+				resolve();
+			}, 15);
+		});
 	});
 
-	it('should update balances on interval', () => {
-		const clock = sandbox.useFakeTimers();
-		tokenBalances.configure({ interval: 180000 });
-		const updateBalances = sandbox.stub(tokenBalances, 'updateBalances');
-		clock.tick(180001);
-		expect(updateBalances.called).toBe(true);
+	it('should not update rates if disabled', async () => {
+		const controller = new TokenBalancesController({
+			disabled: true,
+			interval: 10
+		});
+		const mock = stub(controller, 'update');
+		await controller.updateBalances();
+		expect(mock.called).toBe(false);
+	});
+
+	it('should clear previous interval', () => {
+		const mock = stub(global, 'clearTimeout');
+		const controller = new TokenBalancesController({ interval: 1337 });
+		return new Promise((resolve) => {
+			setTimeout(() => {
+				controller.poll(1338);
+				expect(mock.called).toBe(true);
+				mock.restore();
+				resolve();
+			}, 100);
+		});
 	});
 
 	it('should update all balances', async () => {
@@ -65,28 +87,6 @@ describe('TokenBalancesController', () => {
 		await tokenBalances.updateBalances();
 		expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
 		expect(tokenBalances.state.contractBalances[address].toNumber()).toBeGreaterThan(0);
-	});
-
-	it('should not update balances if disabled', async () => {
-		tokenBalances.disabled = true;
-		const assets = new AssetsController();
-		const assetsContract = new AssetsContractController();
-		const network = new NetworkController();
-		const preferences = new PreferencesController();
-		/* tslint:disable-next-line:no-unused-expression */
-		new ComposableController([assets, assetsContract, network, preferences, tokenBalances]);
-		assetsContract.configure({ provider: MAINNET_PROVIDER });
-		const getBalanceOf = sandbox.stub(assetsContract, 'getBalanceOf');
-		await tokenBalances.updateBalances();
-		expect(getBalanceOf.called).toBe(false);
-	});
-
-	it('should clear previous interval', () => {
-		const func = sandbox.stub(global, 'clearInterval');
-		const controller = new TokenBalancesController({ interval: 1337 });
-		controller.interval = 1338;
-		expect(func.called).toBe(true);
-		func.restore();
 	});
 
 	it('should subscribe to new sibling assets controllers', async () => {

--- a/src/TokenBalancesController.ts
+++ b/src/TokenBalancesController.ts
@@ -66,12 +66,12 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
 	}
 
 	/**
-	 * starts a new polling interval
+	 * Starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new token balances
 	 */
-	async poll(interval?: number) {
-		this.config.interval = interval || this.config.interval;
+	async poll(interval?: number): Promise<void> {
+		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateBalances());
 		this.handle = setTimeout(() => {

--- a/src/TokenBalancesController.ts
+++ b/src/TokenBalancesController.ts
@@ -62,18 +62,21 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
 		};
 		this.defaultState = { contractBalances: {} };
 		this.initialize();
+		this.poll();
 	}
 
 	/**
-	 * Sets a new polling interval
+	 * starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new token balances
 	 */
-	set interval(interval: number) {
-		this.handle && clearInterval(this.handle);
-		this.handle = setInterval(() => {
-			safelyExecute(() => this.updateBalances());
-		}, interval);
+	async poll(interval?: number) {
+		this.config.interval = interval || this.config.interval;
+		this.handle && clearTimeout(this.handle);
+		await safelyExecute(() => this.updateBalances());
+		this.handle = setTimeout(() => {
+			this.poll(this.config.interval);
+		}, this.config.interval);
 	}
 
 	/**

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -103,8 +103,8 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	 *
 	 * @param interval - Polling interval used to fetch new token rates
 	 */
-	async poll(interval?: number) {
-		this.config.interval = interval || this.config.interval;
+	async poll(interval?: number): Promise<void> {
+		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateExchangeRates());
 		this.handle = setTimeout(() => {
@@ -119,7 +119,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	 */
 	set tokens(tokens: Token[]) {
 		this.tokenList = tokens;
-		safelyExecute(() => this.updateExchangeRates());
+		!this.disabled && safelyExecute(() => this.updateExchangeRates());
 	}
 
 	/**
@@ -156,7 +156,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	 * @returns Promise resolving when this operation completes
 	 */
 	async updateExchangeRates() {
-		if (this.disabled || this.tokenList.length === 0) {
+		if (this.tokenList.length === 0) {
 			return;
 		}
 		const newContractExchangeRates: { [address: string]: number } = {};

--- a/src/TransactionController.test.ts
+++ b/src/TransactionController.test.ts
@@ -125,32 +125,32 @@ describe('TransactionController', () => {
 		});
 	});
 
-	it('should poll on correct interval', () => {
-		const func = stub(global, 'setInterval');
-		/* tslint:disable-next-line:no-unused-expression */
-		new TransactionController({ interval: 1337 });
-		expect(func.getCall(0).args[1]).toBe(1337);
-		func.restore();
-	});
-
-	it('should check transaction statuses on interval', () => {
+	it('should poll and update transaction statuses in the right interval', () => {
 		return new Promise((resolve) => {
-			const controller = new TransactionController({ interval: 10 });
-			const func = stub(controller, 'queryTransactionStatuses');
+			const mock = stub(TransactionController.prototype, 'queryTransactionStatuses');
+			// tslint:disable-next-line: no-unused-expression
+			new TransactionController({ interval: 10 });
+			expect(mock.called).toBe(true);
+			expect(mock.calledTwice).toBe(false);
 			setTimeout(() => {
-				expect(func.called).toBe(true);
-				func.restore();
+				expect(mock.calledTwice).toBe(true);
+				mock.restore();
 				resolve();
-			}, 20);
+			}, 15);
 		});
 	});
 
 	it('should clear previous interval', () => {
-		const func = stub(global, 'clearInterval');
+		const mock = stub(global, 'clearTimeout');
 		const controller = new TransactionController({ interval: 1337 });
-		controller.interval = 1338;
-		expect(func.called).toBe(true);
-		func.restore();
+		return new Promise((resolve) => {
+			setTimeout(() => {
+				controller.poll(1338);
+				expect(mock.called).toBe(true);
+				mock.restore();
+				resolve();
+			}, 100);
+		});
 	});
 
 	it('should not update the state if there are no updates on transaction statuses', () => {

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -239,19 +239,21 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		};
 		this.defaultState = { transactions: [] };
 		this.initialize();
+		this.poll();
 	}
 
 	/**
-	 * Sets a new polling interval
+	 * starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new transaction statuses
 	 */
-	set interval(interval: number) {
-		this.handle && clearInterval(this.handle);
-		safelyExecute(() => this.queryTransactionStatuses());
-		this.handle = setInterval(() => {
-			safelyExecute(() => this.queryTransactionStatuses());
-		}, interval);
+	async poll(interval?: number) {
+		this.config.interval = interval || this.config.interval;
+		this.handle && clearTimeout(this.handle);
+		await safelyExecute(() => this.queryTransactionStatuses());
+		this.handle = setTimeout(() => {
+			this.poll(this.config.interval);
+		}, this.config.interval);
 	}
 
 	/**

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -243,12 +243,12 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 	}
 
 	/**
-	 * starts a new polling interval
+	 * Starts a new polling interval
 	 *
 	 * @param interval - Polling interval used to fetch new transaction statuses
 	 */
-	async poll(interval?: number) {
-		this.config.interval = interval || this.config.interval;
+	async poll(interval?: number): Promise<void> {
+		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.queryTransactionStatuses());
 		this.handle = setTimeout(() => {


### PR DESCRIPTION
This PR fixes a couple of things:
- Replaces all `setInterval` ocurrences for recursive `setTimeout`
- Polling will wait for the last call to finish (or fail) before triggering a new one
- Prevent multiple calls to happen on init (`CurrencyController` and `TokenRatesController`) by disabling the controller until after init.

Fixes #64 