### PR TITLE
bugfix: add address validation and improve safelyExecute

### DIFF
--- a/src/AddressBookController.test.ts
+++ b/src/AddressBookController.test.ts
@@ -8,21 +8,29 @@ describe('AddressBookController', () => {
 
 	it('should add a contact entry', () => {
 		const controller = new AddressBookController();
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
+		expect(controller.state).toEqual({
+			addressBook: [{ address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88', name: 'foo' }]
+		});
+	});
+
+	it('should not add invalid contact entry', () => {
+		const controller = new AddressBookController();
 		controller.set('1337', 'foo');
-		expect(controller.state).toEqual({ addressBook: [{ address: '1337', name: 'foo' }] });
+		expect(controller.state).toEqual({ addressBook: [] });
 	});
 
 	it('should remove a contact entry', () => {
 		const controller = new AddressBookController();
-		controller.set('1337', 'foo');
-		controller.delete('1337');
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
+		controller.delete('0x32Be343B94f860124dC4fEe278FDCBD38C102D88');
 		expect(controller.state).toEqual({ addressBook: [] });
 	});
 
 	it('should clear all contact entries', () => {
 		const controller = new AddressBookController();
-		controller.set('1337', 'foo');
-		controller.set('1338', 'bar');
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'bar');
 		controller.clear();
 		expect(controller.state).toEqual({ addressBook: [] });
 	});

--- a/src/AddressBookController.ts
+++ b/src/AddressBookController.ts
@@ -1,5 +1,7 @@
 import BaseController, { BaseConfig, BaseState } from './BaseController';
 
+const { isValidAddress } = require('ethereumjs-util');
+
 /**
  * @type ContactEntry
  *
@@ -70,10 +72,15 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 	 *
 	 * @param address - Recipient address to add or update
 	 * @param name - Nickname to associate with this address
+	 * @returns - Boolean indicating if the address was successfully set
 	 */
 	set(address: string, name: string) {
+		if (!isValidAddress(address)) {
+			return;
+		}
 		this.addressBook.set(address, { address, name });
 		this.update({ addressBook: Array.from(this.addressBook.values()) });
+		return true;
 	}
 }
 

--- a/src/AddressBookController.ts
+++ b/src/AddressBookController.ts
@@ -76,7 +76,7 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 	 */
 	set(address: string, name: string) {
 		if (!isValidAddress(address)) {
-			return;
+			return false;
 		}
 		this.addressBook.set(address, { address, name });
 		this.update({ addressBook: Array.from(this.addressBook.values()) });

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -97,9 +97,9 @@ describe('ComposableController', () => {
 		const addressContext = controller.context.TokenRatesController.context
 			.AddressBookController as AddressBookController;
 		expect(addressContext).toBeDefined();
-		addressContext.set('1337', 'foo');
+		addressContext.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
 		expect(controller.flatState).toEqual({
-			addressBook: [{ address: '1337', name: 'foo' }],
+			addressBook: [{ address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88', name: 'foo' }],
 			allCollectibleContracts: {},
 			allCollectibles: {},
 			allTokens: {},
@@ -148,11 +148,11 @@ describe('ComposableController', () => {
 		const controller = new ComposableController([addressBookController]);
 		const listener = stub();
 		controller.subscribe(listener);
-		addressBookController.set('1337', 'foo');
+		addressBookController.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
 		expect(listener.calledOnce).toBe(true);
 		expect(listener.getCall(0).args[0]).toEqual({
 			AddressBookController: {
-				addressBook: [{ address: '1337', name: 'foo' }]
+				addressBook: [{ address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88', name: 'foo' }]
 			}
 		});
 	});

--- a/src/PreferencesController.test.ts
+++ b/src/PreferencesController.test.ts
@@ -72,11 +72,9 @@ describe('PreferencesController', () => {
 		const controller = new PreferencesController();
 		controller.addToFrequentRpcList('rpc_url');
 		controller.addToFrequentRpcList('http://localhost:8545');
-		controller.addToFrequentRpcList('http://localhost:1337');
-		controller.addToFrequentRpcList('http://127.0.0.1:1337');
-		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
+		expect(controller.state.frequentRpcList).toEqual(['rpc_url', 'http://localhost:8545']);
 		controller.addToFrequentRpcList('rpc_url');
-		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
+		expect(controller.state.frequentRpcList).toEqual(['http://localhost:8545', 'rpc_url']);
 	});
 
 	it('should remove custom rpc url', () => {
@@ -84,8 +82,6 @@ describe('PreferencesController', () => {
 		controller.addToFrequentRpcList('rpc_url');
 		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
 		controller.removeFromFrequentRpcList('other_rpc_url');
-		controller.removeFromFrequentRpcList('http://localhost:8545');
-		controller.removeFromFrequentRpcList('http://localhost:1337');
 		controller.removeFromFrequentRpcList('rpc_url');
 		expect(controller.state.frequentRpcList).toEqual([]);
 	});

--- a/src/PreferencesController.test.ts
+++ b/src/PreferencesController.test.ts
@@ -73,6 +73,7 @@ describe('PreferencesController', () => {
 		controller.addToFrequentRpcList('rpc_url');
 		controller.addToFrequentRpcList('http://localhost:8545');
 		controller.addToFrequentRpcList('http://localhost:1337');
+		controller.addToFrequentRpcList('http://127.0.0.1:1337');
 		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
 		controller.addToFrequentRpcList('rpc_url');
 		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);

--- a/src/PreferencesController.test.ts
+++ b/src/PreferencesController.test.ts
@@ -72,6 +72,7 @@ describe('PreferencesController', () => {
 		const controller = new PreferencesController();
 		controller.addToFrequentRpcList('rpc_url');
 		controller.addToFrequentRpcList('http://localhost:8545');
+		controller.addToFrequentRpcList('http://localhost:1337');
 		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
 		controller.addToFrequentRpcList('rpc_url');
 		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
@@ -83,6 +84,7 @@ describe('PreferencesController', () => {
 		expect(controller.state.frequentRpcList).toEqual(['rpc_url']);
 		controller.removeFromFrequentRpcList('other_rpc_url');
 		controller.removeFromFrequentRpcList('http://localhost:8545');
+		controller.removeFromFrequentRpcList('http://localhost:1337');
 		controller.removeFromFrequentRpcList('rpc_url');
 		expect(controller.state.frequentRpcList).toEqual([]);
 	});

--- a/src/PreferencesController.ts
+++ b/src/PreferencesController.ts
@@ -31,10 +31,6 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	 */
 	name = 'PreferencesController';
 
-	private isLocalURL(url: string) {
-		return /:\/\/((localhost)|(127\.0\.0\.1)):/.test(url);
-	}
-
 	/**
 	 * Creates a PreferencesController instance
 	 *
@@ -174,9 +170,6 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	 * @param url - Custom RPC URL
 	 */
 	addToFrequentRpcList(url: string) {
-		if (this.isLocalURL(url)) {
-			return;
-		}
 		const frequentRpcList = this.state.frequentRpcList;
 		const index = frequentRpcList.findIndex((element) => {
 			return element === url;
@@ -194,9 +187,6 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	 * @param url - Custom RPC URL
 	 */
 	removeFromFrequentRpcList(url: string) {
-		if (this.isLocalURL(url)) {
-			return;
-		}
 		const frequentRpcList = this.state.frequentRpcList;
 		const index = frequentRpcList.findIndex((element) => {
 			return element === url;

--- a/src/PreferencesController.ts
+++ b/src/PreferencesController.ts
@@ -32,7 +32,7 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	name = 'PreferencesController';
 
 	private isLocalURL(url: string) {
-		return /:\/\/localhost:/.test(url);
+		return /:\/\/((localhost)|(127\.0\.0\.1)):/.test(url);
 	}
 
 	/**

--- a/src/PreferencesController.ts
+++ b/src/PreferencesController.ts
@@ -31,6 +31,10 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	 */
 	name = 'PreferencesController';
 
+	private isLocalURL(url: string) {
+		return /:\/\/localhost:/.test(url);
+	}
+
 	/**
 	 * Creates a PreferencesController instance
 	 *
@@ -170,7 +174,7 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	 * @param url - Custom RPC URL
 	 */
 	addToFrequentRpcList(url: string) {
-		if (url === 'http://localhost:8545') {
+		if (this.isLocalURL(url)) {
 			return;
 		}
 		const frequentRpcList = this.state.frequentRpcList;
@@ -190,7 +194,7 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	 * @param url - Custom RPC URL
 	 */
 	removeFromFrequentRpcList(url: string) {
-		if (url === 'http://localhost:8545') {
+		if (this.isLocalURL(url)) {
 			return;
 		}
 		const frequentRpcList = this.state.frequentRpcList;

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -49,9 +49,23 @@ describe('util', () => {
 		});
 	});
 
-	it('safelyExecute', async () => {
-		await util.safelyExecute(() => {
-			throw new Error('ahh');
+	describe('safelyExecute', () => {
+		it('should swallow errors', async () => {
+			await util.safelyExecute(() => {
+				throw new Error('ahh');
+			});
+		});
+
+		it('should call retry function', () => {
+			return new Promise((resolve) => {
+				util.safelyExecute(
+					() => {
+						throw new Error('ahh');
+					},
+					true,
+					resolve
+				);
+			});
 		});
 	});
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -113,13 +113,16 @@ export function normalizeTransaction(transaction: Transaction) {
  * Execute and return an asynchronous operation without throwing errors
  *
  * @param operation - Function returning a Promise
+ * @param logError - Determines if the error should be logged
+ * @param retry - Function called if an error is caught
  * @returns - Promise resolving to the result of the async operation
  */
-export async function safelyExecute(operation: () => Promise<any>) {
+export async function safelyExecute(operation: () => Promise<any>, logError = false, retry?: (error: Error) => void) {
 	try {
 		return await operation();
 	} catch (error) {
-		/* tslint:disable-next-line:no-empty */
+		logError && console.error(error);
+		retry && retry(error);
 	}
 }
 


### PR DESCRIPTION
This pull request does the following:

- `safelyExecute` optionally logs errors and provides an optional retry logic path.
- The `AddressBookController` validates newly-added addresses.
- The `PreferencesController` loosely checks local RPC URLs (though this was technically unnecessary since we're checking against a constant string value [we set internally](https://github.com/MetaMask/gaba/blob/master/src/NetworkController.ts#L50).)

Fixes #65
Fixes #67
Fixes #70