### PR TITLE
Feature: EIP747 watchAsset

### DIFF
--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -527,6 +527,14 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		return newTokens;
 	}
 
+	/**
+	 * Adds a new suggestedAsset to state. Parameters will be validated according to
+	 * asset type being watched. A `<suggestedAssetMeta.id>:pending` hub event will be emitted once added.
+	 *
+	 * @param asset - Asset to be watched. For now only ERC20 tokens are accepted.
+	 * @param type - Asset type
+	 * @returns - Object containing a promise resolving to the suggestedAsset address if accepted
+	 */
 	async watchAsset(asset: Token, type: string): Promise<AssetSuggestionResult> {
 		const suggestedAssetMeta: SuggestedAssetMeta = {
 			asset,
@@ -567,7 +575,15 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		return { result, suggestedAssetMeta };
 	}
 
-	async acceptWatchAsset(suggestedAssetID: string) {
+	/**
+	 * Accepts to watch an asset and updates it's status and deletes the suggestedAsset from state,
+	 * adding the asset to corresponding asset state. In this case ERC20 tokens.
+	 * A `<suggestedAssetMeta.id>:finished` hub event is fired after accepted or failure.
+	 *
+	 * @param suggestedAssetID - ID of the suggestedAsset to accept
+	 * @returns - Promise resolving when this operation completes
+	 */
+	async acceptWatchAsset(suggestedAssetID: string): Promise<void> {
 		const { suggestedAssets } = this.state;
 		const index = suggestedAssets.findIndex(({ id }) => suggestedAssetID === id);
 		const suggestedAssetMeta = suggestedAssets[index];
@@ -589,7 +605,13 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		this.update({ suggestedAssets: [...newSuggestedAssets] });
 	}
 
-	async rejectWatchAsset(suggestedAssetID: string) {
+	/**
+	 * Rejects a watchAsset request based on its ID by setting its status to "rejected"
+	 * and emitting a `<suggestedAssetMeta.id>:finished` hub event.
+	 *
+	 * @param suggestedAssetID - ID of the suggestedAsset to accept
+	 */
+	rejectWatchAsset(suggestedAssetID: string) {
 		const { suggestedAssets } = this.state;
 		const index = suggestedAssets.findIndex(({ id }) => suggestedAssetID === id);
 		const suggestedAssetMeta = suggestedAssets[index];

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -4,10 +4,12 @@ import PreferencesController from './PreferencesController';
 import NetworkController, { NetworkType } from './NetworkController';
 import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
-import { safelyExecute, handleFetch } from './util';
+import { safelyExecute, handleFetch, validateTokenToWatch } from './util';
+import { EventEmitter } from 'events';
 
 const { toChecksumAddress } = require('ethereumjs-util');
 const Mutex = require('await-semaphore').Mutex;
+const random = require('uuid/v1');
 
 /**
  * @type Collectible
@@ -97,6 +99,41 @@ export interface AssetsConfig extends BaseConfig {
 }
 
 /**
+ * @type AssetSuggestionResult
+ *
+ * @property result - Promise resolving to a new suggested asset address
+ * @property suggestedAssetMeta - Meta information about this new suggested asset
+ */
+export interface AssetSuggestionResult {
+	result: Promise<string>;
+	suggestedAssetMeta: SuggestedAssetMeta;
+}
+
+/**
+ * @type SuggestedAssetMeta
+ *
+ * Suggested asset by EIP747 meta data
+ *
+ * @property error - Synthesized error information for failed asset suggestions
+ * @property id - Generated UUID associated with this suggested asset
+ * @property status - String status of this this suggested asset
+ * @property time - Timestamp associated with this this suggested asset
+ * @property type - Type type this suggested asset
+ * @property asset - Asset suggested object
+ */
+export interface SuggestedAssetMeta {
+	error?: {
+		message: string;
+		stack?: string;
+	};
+	id: string;
+	status: string;
+	time: number;
+	type: string;
+	asset: Token;
+}
+
+/**
  * @type AssetsState
  *
  * Assets controller state
@@ -106,6 +143,7 @@ export interface AssetsConfig extends BaseConfig {
  * @property allCollectibles - Object containing collectibles per account and network
  * @property collectibleContracts - List of collectibles contracts associated with the active vault
  * @property collectibles - List of collectibles associated with the active vault
+ * @property suggestedAssets - List of suggested assets associated with the active vault
  * @property tokens - List of tokens associated with the active vault
  */
 export interface AssetsState extends BaseState {
@@ -114,6 +152,7 @@ export interface AssetsState extends BaseState {
 	allCollectibles: { [key: string]: { [key: string]: Collectible[] } };
 	collectibleContracts: CollectibleContract[];
 	collectibles: Collectible[];
+	suggestedAssets: SuggestedAssetMeta[];
 	tokens: Token[];
 }
 
@@ -129,6 +168,15 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 
 	private getCollectibleContractInformationApi(contractAddress: string) {
 		return `https://api.opensea.io/api/v1/asset_contract/${contractAddress}`;
+	}
+
+	private failSuggestedAsset(suggestedAssetMeta: SuggestedAssetMeta, error: Error) {
+		suggestedAssetMeta.status = 'failed';
+		suggestedAssetMeta.error = {
+			message: error.toString(),
+			stack: error.stack
+		};
+		this.hub.emit(`${suggestedAssetMeta.id}:finished`, suggestedAssetMeta);
 	}
 
 	/**
@@ -410,6 +458,11 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	}
 
 	/**
+	 * EventEmitter instance used to listen to specific EIP747 events
+	 */
+	hub = new EventEmitter();
+
+	/**
 	 * Name of this controller used during composition
 	 */
 	name = 'AssetsController';
@@ -437,6 +490,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			allTokens: {},
 			collectibleContracts: [],
 			collectibles: [],
+			suggestedAssets: [],
 			tokens: []
 		};
 		this.initialize();
@@ -471,6 +525,81 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		this.update({ allTokens: newAllTokens, tokens: newTokens });
 		releaseLock();
 		return newTokens;
+	}
+
+	async watchAsset(asset: Token, type: string): Promise<AssetSuggestionResult> {
+		const suggestedAssetMeta: SuggestedAssetMeta = {
+			asset,
+			id: random(),
+			status: 'pending',
+			time: Date.now(),
+			type
+		};
+		try {
+			switch (type) {
+				case 'ERC20':
+					validateTokenToWatch(asset);
+					break;
+				default:
+					throw new Error(`Asset of type ${type} not supported`);
+			}
+		} catch (error) {
+			this.failSuggestedAsset(suggestedAssetMeta, error);
+			return Promise.reject(error);
+		}
+
+		const result: Promise<string> = new Promise((resolve, reject) => {
+			this.hub.once(`${suggestedAssetMeta.id}:finished`, (meta: SuggestedAssetMeta) => {
+				switch (meta.status) {
+					case 'accepted':
+						return resolve(meta.asset.address);
+					case 'rejected':
+						return reject(new Error('User rejected to watch the asset.'));
+					case 'failed':
+						return reject(new Error(meta.error!.message));
+				}
+			});
+		});
+		const { suggestedAssets } = this.state;
+		suggestedAssets.push(suggestedAssetMeta);
+		this.update({ suggestedAssets: [...suggestedAssets] });
+		this.hub.emit('pendingSuggestedAsset', suggestedAssetMeta);
+		return { result, suggestedAssetMeta };
+	}
+
+	async acceptWatchAsset(suggestedAssetID: string) {
+		const { suggestedAssets } = this.state;
+		const index = suggestedAssets.findIndex(({ id }) => suggestedAssetID === id);
+		const suggestedAssetMeta = suggestedAssets[index];
+		try {
+			switch (suggestedAssetMeta.type) {
+				case 'ERC20':
+					const { address, symbol, decimals, image } = suggestedAssetMeta.asset;
+					await this.addToken(address, symbol, decimals, image);
+					suggestedAssetMeta.status = 'accepted';
+					this.hub.emit(`${suggestedAssetMeta.id}:finished`, suggestedAssetMeta);
+					break;
+				default:
+					throw new Error(`Asset of type ${suggestedAssetMeta.type} not supported`);
+			}
+		} catch (error) {
+			this.failSuggestedAsset(suggestedAssetMeta, error);
+		}
+		const newSuggestedAssets = suggestedAssets.filter(({ id }) => id !== suggestedAssetID);
+		this.update({ suggestedAssets: [...newSuggestedAssets] });
+	}
+
+	async rejectWatchAsset(suggestedAssetID: string) {
+		const { suggestedAssets } = this.state;
+		const index = suggestedAssets.findIndex(({ id }) => suggestedAssetID === id);
+		const suggestedAssetMeta = suggestedAssets[index];
+		if (!suggestedAssetMeta) {
+			return;
+		}
+		suggestedAssetMeta.status = 'rejected';
+		this.hub.emit(`${suggestedAssetMeta.id}:finished`, suggestedAssetMeta);
+		const newSuggestedAssets = suggestedAssets.filter(({ id }) => id !== suggestedAssetID);
+		this.update({ suggestedAssets: [...newSuggestedAssets] });
 	}
 
 	/**

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -448,14 +448,15 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	 * @param address - Hex address of the token contract
 	 * @param symbol - Symbol of the token
 	 * @param decimals - Number of decimals the token uses
+	 * @param image - Image of the token
 	 * @returns - Current token list
 	 */
-	async addToken(address: string, symbol: string, decimals: number): Promise<Token[]> {
+	async addToken(address: string, symbol: string, decimals: number, image?: string): Promise<Token[]> {
 		const releaseLock = await this.mutex.acquire();
 		address = toChecksumAddress(address);
 		const { allTokens, tokens } = this.state;
 		const { networkType, selectedAddress } = this.config;
-		const newEntry: Token = { address, symbol, decimals };
+		const newEntry: Token = { address, symbol, decimals, image };
 		const previousEntry = tokens.find((token) => token.address === address);
 		if (previousEntry) {
 			const previousIndex = tokens.indexOf(previousEntry);

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -28,6 +28,7 @@ describe('ComposableController', () => {
 				allTokens: {},
 				collectibleContracts: [],
 				collectibles: [],
+				suggestedAssets: [],
 				tokens: []
 			},
 			CurrencyRateController: {
@@ -80,6 +81,7 @@ describe('ComposableController', () => {
 			network: 'loading',
 			provider: { type: 'mainnet' },
 			selectedAddress: '',
+			suggestedAssets: [],
 			tokens: []
 		});
 	});
@@ -117,6 +119,7 @@ describe('ComposableController', () => {
 			network: 'loading',
 			provider: { type: 'mainnet' },
 			selectedAddress: '',
+			suggestedAssets: [],
 			tokens: []
 		});
 	});

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -24,11 +24,13 @@ export interface Balanc3Response {
  * @property address - Hex address of the token contract
  * @property decimals - Number of decimals the token uses
  * @property symbol - Symbol of the token
+ * @property image - Image of the token, url or bit32 image
  */
 export interface Token {
 	address: string;
 	decimals: number;
 	symbol: string;
+	image?: string;
 }
 
 /**

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -63,6 +63,7 @@ export interface Transaction {
  * @property origin - Origin this transaction was sent from
  * @property rawTransaction - Hex representation of the underlying transaction
  * @property status - String status of this transaction
+ * @property time - Timestamp associated with this transaction
  * @property toSmartContract - Whether transaction recipient is a smart contract
  * @property transaction - Underlying Transaction object
  * @property transactionHash - Hash of a successful transaction

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -388,4 +388,74 @@ describe('util', () => {
 			expect(toSmartContract4).toBe(true);
 		});
 	});
+
+	describe('validateTokenToWatch', () => {
+		it('should throw if undefined token atrributes', () => {
+			expect(() =>
+				util.validateTokenToWatch({
+					address: undefined,
+					decimals: 0,
+					symbol: 'TKN'
+				} as any)
+			).toThrow('Cannot suggest token without address, symbol, and decimals');
+			expect(() =>
+				util.validateTokenToWatch({
+					address: '0x1',
+					decimals: 0,
+					symbol: undefined
+				} as any)
+			).toThrow('Cannot suggest token without address, symbol, and decimals');
+			expect(() =>
+				util.validateTokenToWatch({
+					address: '0x1',
+					decimals: undefined,
+					symbol: 'TKN'
+				} as any)
+			).toThrow('Cannot suggest token without address, symbol, and decimals');
+		});
+
+		it('should throw if symbol is more than 6 characters long', () => {
+			expect(() =>
+				util.validateTokenToWatch({
+					address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
+					decimals: 0,
+					symbol: 'TKNTKNTKN'
+				} as any)
+			).toThrow('Invalid symbol TKNTKNTKN more than six characters');
+		});
+
+		it('should throw if invalid decimals', () => {
+			expect(() =>
+				util.validateTokenToWatch({
+					address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
+					decimals: 0,
+					symbol: 'TKN'
+				} as any)
+			).not.toThrow();
+			expect(() =>
+				util.validateTokenToWatch({
+					address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
+					decimals: 38,
+					symbol: 'TKN'
+				} as any)
+			).toThrow('Invalid decimals 38 must be at least 0, and not over 36');
+			expect(() =>
+				util.validateTokenToWatch({
+					address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
+					decimals: -1,
+					symbol: 'TKN'
+				} as any)
+			).toThrow('Invalid decimals -1 must be at least 0, and not over 36');
+		});
+
+		it('should throw if invalid address', () => {
+			expect(() =>
+				util.validateTokenToWatch({
+					address: '0xe9',
+					decimals: 0,
+					symbol: 'TKN'
+				} as any)
+			).toThrow('Invalid address 0xe9');
+		});
+	});
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -308,6 +308,7 @@ export default {
 	isSmartContractCode,
 	normalizeTransaction,
 	safelyExecute,
+	validateTokenToWatch,
 	validateTransaction,
 	validateTypedSignMessageDataV1,
 	validateTypedSignMessageDataV3

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,8 @@
 import { Transaction } from './TransactionController';
 import { PersonalMessageParams } from './PersonalMessageManager';
 import { TypedMessageParams } from './TypedMessageManager';
+import { Token } from './TokenRatesController';
+
 const sigUtil = require('eth-sig-util');
 const jsonschema = require('jsonschema');
 const { addHexPrefix, BN, isValidAddress, stripHexPrefix, bufferToHex } = require('ethereumjs-util');
@@ -257,6 +259,27 @@ export function validateTypedSignMessageDataV3(messageData: TypedMessageParams, 
 	const chainId = data.domain.chainId;
 	if (chainId !== activeChainId) {
 		throw new Error(`Provided chainId (${chainId}) must match the active chainId (${activeChainId})`);
+	}
+}
+
+/**
+ * Validates a ERC20 token to be added with EIP747.
+ *
+ * @param token - Token object to validate
+ */
+export function validateTokenToWatch(token: Token) {
+	const { address, symbol, decimals } = token;
+	if (!address || !symbol || typeof decimals === 'undefined') {
+		throw new Error(`Cannot suggest token without address, symbol, and decimals`);
+	}
+	if (!(symbol.length < 7)) {
+		throw new Error(`Invalid symbol ${symbol} more than six characters`);
+	}
+	if (isNaN(decimals) || decimals > 36 || decimals < 0) {
+		throw new Error(`Invalid decimals ${decimals} must be at least 0, and not over 36`);
+	}
+	if (!isValidAddress(address)) {
+		throw new Error(`Invalid address ${address}`);
 	}
 }
 


### PR DESCRIPTION
This PR adds support to handle EIP747 from `AssetsController` and was mostly inspired mostly on how we handle transactions in `TransactionController`.
For now these methods only support `Token`s, but was meant to easily add new types of assets in the future. 