### PR TITLE
Bugfix: Controllers disabled while initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,7 +2570,7 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
@@ -3448,7 +3448,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3469,12 +3470,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3489,17 +3492,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3616,7 +3622,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3628,6 +3635,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3642,6 +3650,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3649,12 +3658,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3673,6 +3684,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3753,7 +3765,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3765,6 +3778,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3850,7 +3864,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3886,6 +3901,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3905,6 +3921,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3948,12 +3965,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8977,7 +8996,7 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
@@ -9015,7 +9034,7 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {

--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -11,9 +11,11 @@ export type Listener<T> = (state: T) => void;
  * Base controller configuration
  *
  * @property disabled - Determines if this controller is enabled
+ * @property initialization - Determines if this controller is being initialized
  */
 export interface BaseConfig {
 	disabled?: boolean;
+	initialization?: boolean;
 }
 
 /**

--- a/src/CurrencyRateController.test.ts
+++ b/src/CurrencyRateController.test.ts
@@ -24,6 +24,7 @@ describe('CurrencyRateController', () => {
 		const controller = new CurrencyRateController();
 		expect(controller.config).toEqual({
 			currentCurrency: 'usd',
+			initialization: true,
 			interval: 180000,
 			nativeCurrency: 'eth'
 		});

--- a/src/CurrencyRateController.test.ts
+++ b/src/CurrencyRateController.test.ts
@@ -24,7 +24,7 @@ describe('CurrencyRateController', () => {
 		const controller = new CurrencyRateController();
 		expect(controller.config).toEqual({
 			currentCurrency: 'usd',
-			initialization: true,
+			initialization: false,
 			interval: 180000,
 			nativeCurrency: 'eth'
 		});

--- a/src/CurrencyRateController.test.ts
+++ b/src/CurrencyRateController.test.ts
@@ -24,24 +24,21 @@ describe('CurrencyRateController', () => {
 		const controller = new CurrencyRateController();
 		expect(controller.config).toEqual({
 			currentCurrency: 'usd',
-			disabled: true,
 			interval: 180000,
 			nativeCurrency: 'eth'
 		});
 	});
 
-	it('should poll and update rate in the right interval', () => {
+	it('should poll and update rate in the right interval', async () => {
 		return new Promise((resolve) => {
 			const mock = stub(CurrencyRateController.prototype, 'fetchExchangeRate');
 			// tslint:disable-next-line: no-unused-expression
-			new CurrencyRateController({ interval: 10 });
-			expect(mock.called).toBe(true);
-			expect(mock.calledTwice).toBe(false);
+			new CurrencyRateController({ interval: 100 });
 			setTimeout(() => {
-				expect(mock.calledTwice).toBe(true);
+				expect(mock.called).toBe(true);
 				mock.restore();
 				resolve();
-			}, 15);
+			}, 150);
 		});
 	});
 

--- a/src/CurrencyRateController.ts
+++ b/src/CurrencyRateController.ts
@@ -65,7 +65,6 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 		super(config, state);
 		this.defaultConfig = {
 			currentCurrency: 'usd',
-			disabled: true,
 			interval: 180000,
 			nativeCurrency: 'eth'
 		};
@@ -76,7 +75,6 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 			nativeCurrency: this.defaultConfig.nativeCurrency
 		};
 		this.initialize();
-		this.disabled = false;
 		this.poll();
 	}
 

--- a/src/CurrencyRateController.ts
+++ b/src/CurrencyRateController.ts
@@ -76,6 +76,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 			nativeCurrency: this.defaultConfig.nativeCurrency
 		};
 		this.initialize();
+		this.configure({ initialization: false });
 		this.poll();
 	}
 
@@ -107,16 +108,12 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	 * @param interval - Polling interval used to fetch new exchange rate
 	 */
 	async poll(interval?: number): Promise<void> {
-		const { initialization } = this.config;
 		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateExchangeRate());
 		this.handle = setTimeout(() => {
 			this.poll(this.config.interval);
 		}, this.config.interval);
-		if (initialization) {
-			this.configure({ initialization: false });
-		}
 	}
 
 	/**

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -28,7 +28,6 @@ describe('TokenRatesController', () => {
 			const controller = new TokenRatesController({
 				interval: 100
 			});
-			controller.tokens = [{ address: '0x1', decimals: 18, symbol: 'EOS' }];
 			const mock = stub(controller, 'updateExchangeRates');
 			expect(mock.called).toBe(false);
 			setTimeout(() => {

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -16,6 +16,7 @@ describe('TokenRatesController', () => {
 	it('should set default config', () => {
 		const controller = new TokenRatesController();
 		expect(controller.config).toEqual({
+			initialization: true,
 			interval: 180000,
 			nativeCurrency: 'eth',
 			tokens: []
@@ -27,6 +28,7 @@ describe('TokenRatesController', () => {
 			const controller = new TokenRatesController({
 				interval: 100
 			});
+			controller.tokens = [{ address: '0x1', decimals: 18, symbol: 'EOS' }];
 			const mock = stub(controller, 'updateExchangeRates');
 			expect(mock.called).toBe(false);
 			setTimeout(() => {

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -16,7 +16,7 @@ describe('TokenRatesController', () => {
 	it('should set default config', () => {
 		const controller = new TokenRatesController();
 		expect(controller.config).toEqual({
-			initialization: true,
+			initialization: false,
 			interval: 180000,
 			nativeCurrency: 'eth',
 			tokens: []

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -16,7 +16,6 @@ describe('TokenRatesController', () => {
 	it('should set default config', () => {
 		const controller = new TokenRatesController();
 		expect(controller.config).toEqual({
-			disabled: true,
 			interval: 180000,
 			nativeCurrency: 'eth',
 			tokens: []
@@ -25,19 +24,15 @@ describe('TokenRatesController', () => {
 
 	it('should poll and update rate in the right interval', () => {
 		return new Promise((resolve) => {
-			const mock = stub(TokenRatesController.prototype, 'fetchExchangeRate');
-			// tslint:disable-next-line: no-unused-expression
-			new TokenRatesController({
-				interval: 10,
-				tokens: [{ address: 'bar', decimals: 0, symbol: '' }]
+			const controller = new TokenRatesController({
+				interval: 100
 			});
-			expect(mock.called).toBe(true);
-			expect(mock.calledTwice).toBe(false);
+			const mock = stub(controller, 'updateExchangeRates');
+			expect(mock.called).toBe(false);
 			setTimeout(() => {
-				expect(mock.calledTwice).toBe(true);
-				mock.restore();
+				expect(mock.called).toBe(true);
 				resolve();
-			}, 15);
+			}, 150);
 		});
 	});
 
@@ -45,10 +40,10 @@ describe('TokenRatesController', () => {
 		const controller = new TokenRatesController({
 			interval: 10
 		});
-		controller.fetchExchangeRate = stub();
+		const mock = stub(controller, 'fetchExchangeRate');
 		controller.disabled = true;
 		await controller.updateExchangeRates();
-		expect((controller.fetchExchangeRate as any).called).toBe(false);
+		expect(mock.called).toBe(false);
 	});
 
 	it('should clear previous interval', () => {

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -102,7 +102,6 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 
 	/**
 	 * Sets a new polling interval
-	 * If it was called during contruction, will set disabled config to false
 	 *
 	 * @param interval - Polling interval used to fetch new token rates
 	 */
@@ -117,8 +116,6 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 
 	/**
 	 * Sets a new token list to track prices
-	 * If config is disabled means that is initializing, so it won't update echange rates
-	 * that is done with poll
 	 *
 	 * @param tokens - List of tokens to track exchange rates for
 	 */

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -89,14 +89,12 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	constructor(config?: Partial<TokenRatesConfig>, state?: Partial<TokenRatesState>) {
 		super(config, state);
 		this.defaultConfig = {
-			disabled: true,
 			interval: 180000,
 			nativeCurrency: 'eth',
 			tokens: []
 		};
 		this.defaultState = { contractExchangeRates: {} };
 		this.initialize();
-		this.disabled = false;
 		this.poll();
 	}
 
@@ -170,7 +168,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 			const address = toChecksumAddress(pair.split('/')[0].toLowerCase());
 			newContractExchangeRates[address] = typeof price === 'number' ? price : 0;
 		});
-		this.update({ contractExchangeRates: newContractExchangeRates });
+		this.update({ contractExchangeRates: { ...newContractExchangeRates } });
 	}
 }
 

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -96,6 +96,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 		};
 		this.defaultState = { contractExchangeRates: {} };
 		this.initialize();
+		this.configure({ initialization: false });
 		this.poll();
 	}
 
@@ -106,14 +107,12 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	 * @param interval - Polling interval used to fetch new token rates
 	 */
 	async poll(interval?: number): Promise<void> {
-		const { initialization } = this.config;
 		interval && this.configure({ interval });
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateExchangeRates());
 		this.handle = setTimeout(() => {
 			this.poll(this.config.interval);
 		}, this.config.interval);
-		initialization && this.configure({ initialization: false });
 	}
 
 	/**


### PR DESCRIPTION
For `CurrencyRateController` and `TokenRatesController` we have a `config` parameter called `disabled` and also another controller param called `disabled` to avoid sending updates to the respective controller listeners, defined to false by default in `BaseController`.
This situation was making mobile to not receive any token rates updates because it was disabled to do so, during initialization.
This PR explicitly creates a new config param `initialization` to be used with the same logic that was before to avoid unnecessary `updateExchangeRates` calls while initialization, without touching `this.disabled` to allow controller listeners be updated on state change.
Note: i had to `npm install` because some dependency in `KeyringController` wasn't working with the current nvm version. I could drop those changes if we need to.