### PR TITLE
Enable partial updates to controller config

### DIFF
--- a/src/AccountTrackerController.ts
+++ b/src/AccountTrackerController.ts
@@ -114,7 +114,7 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
 	 * @param interval - Polling interval trigger a 'refresh'
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.refresh());
 		this.handle = setTimeout(() => {

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -107,7 +107,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 	 * @param interval - Polling interval used to auto detect assets
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.detectAssets());
 		this.handle = setTimeout(() => {

--- a/src/BaseController.test.ts
+++ b/src/BaseController.test.ts
@@ -39,6 +39,13 @@ describe('BaseController', () => {
 		expect(controller.config).toEqual(CONFIG);
 	});
 
+	it('should be able to partially update the config', () => {
+		const controller = new TestController(CONFIG);
+		expect(controller.config).toEqual(CONFIG);
+		controller.configure({ disabled: false }, false, false);
+		expect(controller.config).toEqual({ disabled: false });
+	});
+
 	it('should notify all listeners', () => {
 		const controller = new TestController(undefined, STATE);
 		const listenerOne = stub();

--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -121,6 +121,7 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
 	 *
 	 * @param config - New configuration options
 	 * @param overwrite - Overwrite config instead of merging
+	 * @param fullUpdate - Boolean that defines if the update is partial or not
 	 */
 	configure(config: Partial<C>, overwrite = false, fullUpdate = true) {
 		if (fullUpdate) {

--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -122,12 +122,21 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
 	 * @param config - New configuration options
 	 * @param overwrite - Overwrite config instead of merging
 	 */
-	configure(config: Partial<C>, overwrite = false) {
-		this.internalConfig = overwrite ? (config as C) : Object.assign(this.internalConfig, config);
+	configure(config: Partial<C>, overwrite = false, fullUpdate = true) {
+		if (fullUpdate) {
+			this.internalConfig = overwrite ? (config as C) : Object.assign(this.internalConfig, config);
 
-		for (const key in this.internalConfig) {
-			if (typeof this.internalConfig[key] !== 'undefined') {
-				(this as any)[key as string] = this.internalConfig[key];
+			for (const key in this.internalConfig) {
+				if (typeof this.internalConfig[key] !== 'undefined') {
+					(this as any)[key as string] = this.internalConfig[key];
+				}
+			}
+		} else {
+			for (const key in config) {
+				if (typeof this.internalConfig[key] !== 'undefined') {
+					this.internalConfig[key] = config[key] as any;
+					(this as any)[key as string] = config[key];
+				}
 			}
 		}
 	}

--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -133,6 +133,7 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
 			}
 		} else {
 			for (const key in config) {
+				/* istanbul ignore else */
 				if (typeof this.internalConfig[key] !== 'undefined') {
 					this.internalConfig[key] = config[key] as any;
 					(this as any)[key as string] = config[key];

--- a/src/CurrencyRateController.test.ts
+++ b/src/CurrencyRateController.test.ts
@@ -20,11 +20,11 @@ describe('CurrencyRateController', () => {
 		});
 	});
 
-	it('should set default config', () => {
+	it('should initialize with the default config', () => {
 		const controller = new CurrencyRateController();
 		expect(controller.config).toEqual({
 			currentCurrency: 'usd',
-			disabled: true,
+			disabled: false,
 			interval: 180000,
 			nativeCurrency: 'eth'
 		});

--- a/src/CurrencyRateController.ts
+++ b/src/CurrencyRateController.ts
@@ -30,8 +30,8 @@ export interface CurrencyRateConfig extends BaseConfig {
 export interface CurrencyRateState extends BaseState {
 	conversionDate: number;
 	conversionRate: number;
-	currentCurrency: string;
-	nativeCurrency: string;
+	currentCurrency?: string;
+	nativeCurrency?: string;
 }
 
 /**
@@ -76,7 +76,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 			nativeCurrency: this.defaultConfig.nativeCurrency
 		};
 		this.initialize();
-		this.disabled = false;
+		this.configure({ disabled: false }, false, false);
 		this.poll();
 	}
 
@@ -106,7 +106,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	 * @param interval - Polling interval used to fetch new exchange rate
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateExchangeRate());
 		this.handle = setTimeout(() => {
@@ -147,9 +147,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 		);
 		this.update({
 			conversionDate,
-			conversionRate,
-			currentCurrency: this.activeCurrency,
-			nativeCurrency: this.activeNativeCurrency
+			conversionRate
 		});
 		return this.state;
 	}

--- a/src/CurrencyRateController.ts
+++ b/src/CurrencyRateController.ts
@@ -30,8 +30,8 @@ export interface CurrencyRateConfig extends BaseConfig {
 export interface CurrencyRateState extends BaseState {
 	conversionDate: number;
 	conversionRate: number;
-	currentCurrency?: string;
-	nativeCurrency?: string;
+	currentCurrency: string;
+	nativeCurrency: string;
 }
 
 /**
@@ -147,7 +147,9 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 		);
 		this.update({
 			conversionDate,
-			conversionRate
+			conversionRate,
+			currentCurrency: this.activeCurrency,
+			nativeCurrency: this.activeNativeCurrency
 		});
 		return this.state;
 	}

--- a/src/NetworkStatusController.ts
+++ b/src/NetworkStatusController.ts
@@ -83,7 +83,7 @@ export class NetworkStatusController extends BaseController<NetworkStatusConfig,
 	 * @param interval - Polling interval used to fetch network status
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateNetworkStatuses());
 		this.handle = setTimeout(() => {

--- a/src/PhishingController.ts
+++ b/src/PhishingController.ts
@@ -80,7 +80,7 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 	 * @param interval - Polling interval used to fetch new approval lists
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updatePhishingLists());
 		this.handle = setTimeout(() => {

--- a/src/ShapeShiftController.ts
+++ b/src/ShapeShiftController.ts
@@ -104,7 +104,7 @@ export class ShapeShiftController extends BaseController<ShapeShiftConfig, Shape
 	 * @param interval - Polling interval used to fetch new ShapeShift transactions
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateTransactionList());
 		this.handle = setTimeout(() => {

--- a/src/TokenBalancesController.ts
+++ b/src/TokenBalancesController.ts
@@ -71,7 +71,7 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
 	 * @param interval - Polling interval used to fetch new token balances
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateBalances());
 		this.handle = setTimeout(() => {

--- a/src/TokenRatesController.test.ts
+++ b/src/TokenRatesController.test.ts
@@ -13,10 +13,10 @@ describe('TokenRatesController', () => {
 		expect(controller.state).toEqual({ contractExchangeRates: {} });
 	});
 
-	it('should set default config', () => {
+	it('should initialize with the default config', () => {
 		const controller = new TokenRatesController();
 		expect(controller.config).toEqual({
-			disabled: true,
+			disabled: false,
 			interval: 180000,
 			nativeCurrency: 'eth',
 			tokens: []

--- a/src/TokenRatesController.ts
+++ b/src/TokenRatesController.ts
@@ -96,7 +96,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 		};
 		this.defaultState = { contractExchangeRates: {} };
 		this.initialize();
-		this.disabled = false;
+		this.configure({ disabled: false }, false, false);
 		this.poll();
 	}
 
@@ -106,7 +106,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	 * @param interval - Polling interval used to fetch new token rates
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.updateExchangeRates());
 		this.handle = setTimeout(() => {

--- a/src/TransactionController.ts
+++ b/src/TransactionController.ts
@@ -285,7 +285,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 	 * @param interval - Polling interval used to fetch new transaction statuses
 	 */
 	async poll(interval?: number): Promise<void> {
-		interval && this.configure({ interval });
+		interval && this.configure({ interval }, false, false);
 		this.handle && clearTimeout(this.handle);
 		await safelyExecute(() => this.queryTransactionStatuses());
 		this.handle = setTimeout(() => {


### PR DESCRIPTION
Right now the`configure` method sets again every single existing value in `internalConfig` every time is called.  As a side effect, all the class properties that are declared as setters are being called, triggering undesired behaviors (like multiple repeated API calls).

This PR adds a new optional flag (backwards compatible) that lets the controller update specific parts of the config.