### PR TITLE
Feature: Choose IPFS gateway

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -47,6 +47,7 @@ describe('ComposableController', () => {
 				featureFlags: {},
 				frequentRpcList: [],
 				identities: {},
+				ipfsGateway: 'https://ipfs.io/ipfs/',
 				lostIdentities: {},
 				selectedAddress: ''
 			},
@@ -80,6 +81,7 @@ describe('ComposableController', () => {
 			identities: {},
 			ignoredCollectibles: [],
 			ignoredTokens: [],
+			ipfsGateway: 'https://ipfs.io/ipfs/',
 			lostIdentities: {},
 			nativeCurrency: 'eth',
 			network: 'loading',
@@ -120,6 +122,7 @@ describe('ComposableController', () => {
 			identities: {},
 			ignoredCollectibles: [],
 			ignoredTokens: [],
+			ipfsGateway: 'https://ipfs.io/ipfs/',
 			lostIdentities: {},
 			nativeCurrency: 'eth',
 			network: 'loading',

--- a/src/PreferencesController.test.ts
+++ b/src/PreferencesController.test.ts
@@ -7,6 +7,7 @@ describe('PreferencesController', () => {
 			featureFlags: {},
 			frequentRpcList: [],
 			identities: {},
+			ipfsGateway: 'https://ipfs.io/ipfs/',
 			lostIdentities: {},
 			selectedAddress: ''
 		});
@@ -84,5 +85,11 @@ describe('PreferencesController', () => {
 		controller.removeFromFrequentRpcList('other_rpc_url');
 		controller.removeFromFrequentRpcList('rpc_url');
 		expect(controller.state.frequentRpcList).toEqual([]);
+	});
+
+	it('should set IPFS gateway', () => {
+		const controller = new PreferencesController();
+		controller.setIpfsGateway('https://ipfs.infura.io/ipfs/');
+		expect(controller.state.ipfsGateway).toEqual('https://ipfs.infura.io/ipfs/');
 	});
 });

--- a/src/PreferencesController.ts
+++ b/src/PreferencesController.ts
@@ -17,6 +17,7 @@ const { toChecksumAddress } = require('ethereumjs-util');
 export interface PreferencesState extends BaseState {
 	featureFlags: { [feature: string]: boolean };
 	frequentRpcList: string[];
+	ipfsGateway: string;
 	identities: { [address: string]: ContactEntry };
 	lostIdentities: { [address: string]: ContactEntry };
 	selectedAddress: string;
@@ -43,6 +44,7 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 			featureFlags: {},
 			frequentRpcList: [],
 			identities: {},
+			ipfsGateway: 'https://ipfs.io/ipfs/',
 			lostIdentities: {},
 			selectedAddress: ''
 		};
@@ -195,6 +197,15 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 			frequentRpcList.splice(index, 1);
 		}
 		this.update({ frequentRpcList: [...frequentRpcList] });
+	}
+
+	/**
+	 * Sets new ipfs gateway
+	 *
+	 * @param ipfsGateway - Ipfs gateway string
+	 */
+	setIpfsGateway(ipfsGateway: string) {
+		this.update({ ipfsGateway });
 	}
 }
 

--- a/src/PreferencesController.ts
+++ b/src/PreferencesController.ts
@@ -200,9 +200,9 @@ export class PreferencesController extends BaseController<BaseConfig, Preference
 	}
 
 	/**
-	 * Sets new ipfs gateway
+	 * Sets new IPFS gateway
 	 *
-	 * @param ipfsGateway - Ipfs gateway string
+	 * @param ipfsGateway - IPFS gateway string
 	 */
 	setIpfsGateway(ipfsGateway: string) {
 		this.update({ ipfsGateway });


### PR DESCRIPTION
This PR adds `ipfsGateway` to `PreferencesController` state. The idea of it is maintaining `ipfsGateway` on state and be able to update it.