### PR TITLE
Bugfix: remove and ignore assets

### DIFF
--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -177,12 +177,10 @@ describe('AssetsController', () => {
 		});
 	});
 
-	it('should remove token and add it to the ignoredTokenList', async () => {
+	it('should remove token', async () => {
 		await assetsController.addToken('foo', 'bar', 2);
-		expect(assetsController.state.ignoredTokens.length).toBe(0);
 		assetsController.removeToken('0xfoO');
 		expect(assetsController.state.tokens.length).toBe(0);
-		expect(assetsController.state.ignoredTokens.length).toBe(1);
 	});
 
 	it('should remove token by selected address', async () => {
@@ -533,12 +531,12 @@ describe('AssetsController', () => {
 		await assetsController.addToken('0xfAA', 'bar', 3);
 		expect(assetsController.state.ignoredTokens.length).toBe(0);
 		expect(assetsController.state.tokens.length).toBe(2);
-		assetsController.removeToken('0xfoO');
+		assetsController.removeAndIgnoreToken('0xfoO');
 		expect(assetsController.state.tokens.length).toBe(1);
 		expect(assetsController.state.ignoredTokens.length).toBe(1);
 		await assetsController.addToken('0xfoO', 'bar', 2);
 		expect(assetsController.state.ignoredTokens.length).toBe(1);
-		assetsController.removeToken('0xfoO');
+		assetsController.removeAndIgnoreToken('0xfoO');
 		expect(assetsController.state.ignoredTokens.length).toBe(1);
 	});
 
@@ -549,7 +547,7 @@ describe('AssetsController', () => {
 		expect(assetsController.state.collectibles.length).toBe(2);
 		expect(assetsController.state.ignoredCollectibles.length).toBe(0);
 
-		assetsController.removeCollectible('0xfoO', 1);
+		assetsController.removeAndIgnoreCollectible('0xfoO', 1);
 		expect(assetsController.state.collectibles.length).toBe(1);
 		expect(assetsController.state.ignoredCollectibles.length).toBe(1);
 
@@ -557,7 +555,7 @@ describe('AssetsController', () => {
 		expect(assetsController.state.collectibles.length).toBe(2);
 		expect(assetsController.state.ignoredCollectibles.length).toBe(1);
 
-		assetsController.removeCollectible('0xfoO', 1);
+		assetsController.removeAndIgnoreCollectible('0xfoO', 1);
 		expect(assetsController.state.collectibles.length).toBe(1);
 		expect(assetsController.state.ignoredCollectibles.length).toBe(1);
 	});
@@ -565,7 +563,7 @@ describe('AssetsController', () => {
 	it('should be able to clear the ignoredToken list', async () => {
 		await assetsController.addToken('0xfoO', 'bar', 2);
 		expect(assetsController.state.ignoredTokens.length).toBe(0);
-		assetsController.removeToken('0xfoO');
+		assetsController.removeAndIgnoreToken('0xfoO');
 		expect(assetsController.state.tokens.length).toBe(0);
 		expect(assetsController.state.ignoredTokens.length).toBe(1);
 		assetsController.clearIgnoredTokens();
@@ -578,7 +576,7 @@ describe('AssetsController', () => {
 		expect(assetsController.state.collectibles.length).toBe(1);
 		expect(assetsController.state.ignoredCollectibles.length).toBe(0);
 
-		assetsController.removeCollectible('0xfoO', 1);
+		assetsController.removeAndIgnoreCollectible('0xfoO', 1);
 		expect(assetsController.state.collectibles.length).toBe(0);
 		expect(assetsController.state.ignoredCollectibles.length).toBe(1);
 

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -414,12 +414,12 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	}
 
 	/**
-	 * Removes an individual collectible from the stored token list
+	 * Removes an individual collectible from the stored token list and saves it in ignored collectibles list
 	 *
 	 * @param address - Hex address of the collectible contract
 	 * @param tokenId - Token identifier of the collectible
 	 */
-	private removeIndividualCollectible(address: string, tokenId: number) {
+	private removeAndIgnoreIndividualCollectible(address: string, tokenId: number) {
 		address = toChecksumAddress(address);
 		const { allCollectibles, collectibles, ignoredCollectibles } = this.state;
 		const { networkType, selectedAddress } = this.config;
@@ -434,7 +434,6 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			}
 			return true;
 		});
-
 		const addressCollectibles = allCollectibles[selectedAddress];
 		const newAddressCollectibles = { ...addressCollectibles, ...{ [networkType]: newCollectibles } };
 		const newAllCollectibles = { ...allCollectibles, ...{ [selectedAddress]: newAddressCollectibles } };
@@ -443,6 +442,25 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 			collectibles: newCollectibles,
 			ignoredCollectibles: newIgnoredCollectibles
 		});
+	}
+
+	/**
+	 * Removes an individual collectible from the stored token list
+	 *
+	 * @param address - Hex address of the collectible contract
+	 * @param tokenId - Token identifier of the collectible
+	 */
+	private removeIndividualCollectible(address: string, tokenId: number) {
+		address = toChecksumAddress(address);
+		const { allCollectibles, collectibles } = this.state;
+		const { networkType, selectedAddress } = this.config;
+		const newCollectibles = collectibles.filter(
+			(collectible) => !(collectible.address === address && collectible.tokenId === tokenId)
+		);
+		const addressCollectibles = allCollectibles[selectedAddress];
+		const newAddressCollectibles = { ...addressCollectibles, ...{ [networkType]: newCollectibles } };
+		const newAllCollectibles = { ...allCollectibles, ...{ [selectedAddress]: newAddressCollectibles } };
+		this.update({ allCollectibles: newAllCollectibles, collectibles: newCollectibles });
 	}
 
 	/**
@@ -664,11 +682,11 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	}
 
 	/**
-	 * Removes a token from the stored token list
+	 * Removes a token from the stored token list and saves it in ignored tokens list
 	 *
 	 * @param address - Hex address of the token contract
 	 */
-	removeToken(address: string) {
+	removeAndIgnoreToken(address: string) {
 		address = toChecksumAddress(address);
 		const { allTokens, tokens, ignoredTokens } = this.state;
 		const { networkType, selectedAddress } = this.config;
@@ -688,6 +706,22 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	}
 
 	/**
+	 * Removes a token from the stored token list
+	 *
+	 * @param address - Hex address of the token contract
+	 */
+	removeToken(address: string) {
+		address = toChecksumAddress(address);
+		const { allTokens, tokens } = this.state;
+		const { networkType, selectedAddress } = this.config;
+		const newTokens = tokens.filter((token) => token.address !== address);
+		const addressTokens = allTokens[selectedAddress];
+		const newAddressTokens = { ...addressTokens, ...{ [networkType]: newTokens } };
+		const newAllTokens = { ...allTokens, ...{ [selectedAddress]: newAddressTokens } };
+		this.update({ allTokens: newAllTokens, tokens: newTokens });
+	}
+
+	/**
 	 * Removes a collectible from the stored token list
 	 *
 	 * @param address - Hex address of the collectible contract
@@ -696,6 +730,22 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 	removeCollectible(address: string, tokenId: number) {
 		address = toChecksumAddress(address);
 		this.removeIndividualCollectible(address, tokenId);
+		const { collectibles } = this.state;
+		const remainingCollectible = collectibles.find((collectible) => collectible.address === address);
+		if (!remainingCollectible) {
+			this.removeCollectibleContract(address);
+		}
+	}
+
+	/**
+	 * Removes a collectible from the stored token list and saves it in ignored collectibles list
+	 *
+	 * @param address - Hex address of the collectible contract
+	 * @param tokenId - Token identifier of the collectible
+	 */
+	removeAndIgnoreCollectible(address: string, tokenId: number) {
+		address = toChecksumAddress(address);
+		this.removeAndIgnoreIndividualCollectible(address, tokenId);
 		const { collectibles } = this.state;
 		const remainingCollectible = collectibles.find((collectible) => collectible.address === address);
 		if (!remainingCollectible) {

--- a/src/AssetsDetectionController.test.ts
+++ b/src/AssetsDetectionController.test.ts
@@ -235,7 +235,7 @@ describe('AssetsDetectionController', () => {
 		await assetsDetection.detectCollectibles();
 		expect(assets.state.collectibles.length).toEqual(1);
 		expect(assets.state.ignoredCollectibles.length).toEqual(0);
-		assets.removeCollectible('0x1d963688fe2209a98db35c67a041524822cf04ff', 2577);
+		assets.removeAndIgnoreCollectible('0x1d963688fe2209a98db35c67a041524822cf04ff', 2577);
 		await assetsDetection.detectCollectibles();
 		expect(assets.state.collectibles.length).toEqual(0);
 		expect(assets.state.ignoredCollectibles.length).toEqual(1);
@@ -396,7 +396,7 @@ describe('AssetsDetectionController', () => {
 			.returns({ '0x6810e776880C02933D47DB1b9fc05908e5386b96': new BN(1) });
 		await assetsDetection.detectTokens();
 
-		assets.removeToken('0x6810e776880C02933D47DB1b9fc05908e5386b96');
+		assets.removeAndIgnoreToken('0x6810e776880C02933D47DB1b9fc05908e5386b96');
 		await assetsDetection.detectTokens();
 		expect(assets.state.tokens).toEqual([]);
 	});


### PR DESCRIPTION
This PR maintain changes made in #86 adding specific methods to remove and ignore assets, and maintaining remove assets methods before that PR. 
The motivation of this is to maintain independent methods in `AssetsController`. This change produced that all removed assets would be immediately ignored without having an option to remove without ignore.