### PR TITLE
bugfix: collectibles original image

### DIFF
--- a/src/AssetsDetectionController.test.ts
+++ b/src/AssetsDetectionController.test.ts
@@ -56,7 +56,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1d963688fe2209a98db35c67a041524822cf04ff'
 							},
 							description: 'Description 2577',
-							image_preview_url: 'image/2577.png',
+							image_original_url: 'image/2577.png',
 							name: 'ID 2577',
 							token_id: '2577'
 						}
@@ -76,7 +76,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1d963688fe2209a98db35c67a041524822cf04ff'
 							},
 							description: 'Description 2577',
-							image_preview_url: 'image/2577.png',
+							image_original_url: 'image/2577.png',
 							name: 'ID 2577',
 							token_id: '2577'
 						},
@@ -85,7 +85,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1d963688fe2209a98db35c67a041524822cf04ff'
 							},
 							description: 'Description 2574',
-							image_preview_url: 'image/2574.png',
+							image_original_url: 'image/2574.png',
 							name: 'ID 2574',
 							token_id: '2574'
 						}
@@ -135,7 +135,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1d963688FE2209A98db35c67A041524822CF04gg'
 							},
 							description: 'Description 2577',
-							image_preview_url: 'image/2577.png',
+							image_original_url: 'image/2577.png',
 							name: 'ID 2577',
 							token_id: '2577'
 						},
@@ -144,7 +144,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1d963688FE2209A98db35c67A041524822CF04ii'
 							},
 							description: 'Description 2578',
-							image_preview_url: 'image/2578.png',
+							image_original_url: 'image/2578.png',
 							name: 'ID 2578',
 							token_id: '2578'
 						},
@@ -153,7 +153,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1d963688FE2209A98db35c67A041524822CF04hh'
 							},
 							description: 'Description 2574',
-							image_preview_url: 'image/2574.png',
+							image_original_url: 'image/2574.png',
 							name: 'ID 2574',
 							token_id: '2574'
 						}
@@ -337,7 +337,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1d963688FE2209A98db35c67A041524822CF04ii'
 							},
 							description: 'Description 2577',
-							image_preview_url: 'image/2577.png',
+							image_original_url: 'image/2577.png',
 							name: 'ID 2577',
 							token_id: '2577'
 						},
@@ -346,7 +346,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1D963688fe2209a98dB35c67a041524822Cf04gg'
 							},
 							description: 'Description 2574',
-							image_preview_url: 'image/2574.png',
+							image_original_url: 'image/2574.png',
 							name: 'ID 2574',
 							token_id: '2574'
 						},
@@ -355,7 +355,7 @@ describe('AssetsDetectionController', () => {
 								address: '0x1d963688FE2209A98db35c67A041524822CF04hh'
 							},
 							description: 'Description 2574',
-							image_preview_url: 'image/2574.png',
+							image_original_url: 'image/2574.png',
 							name: 'ID 2574',
 							token_id: '2574'
 						}

--- a/src/AssetsDetectionController.ts
+++ b/src/AssetsDetectionController.ts
@@ -19,14 +19,14 @@ const MAINNET = 'mainnet';
  * Collectible object coming from OpenSea api
  *
  * @property token_id - The collectible identifier
- * @property image_preview_url - URI of collectible image associated with this collectible
+ * @property image_original_url - URI of collectible image associated with this collectible
  * @property name - The collectible name
  * @property description - The collectible description
  * @property assetContract - The collectible contract basic information, in this case the address
  */
 export interface ApiCollectibleResponse {
 	token_id: string;
-	image_preview_url: string;
+	image_original_url: string;
 	name: string;
 	description: string;
 	asset_contract: { [address: string]: string };
@@ -215,7 +215,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 			const addCollectiblesPromises = collectibles.map(async (collectible: ApiCollectibleResponse) => {
 				const {
 					token_id,
-					image_preview_url,
+					image_original_url,
 					name,
 					description,
 					asset_contract: { address }
@@ -236,7 +236,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 						Number(token_id),
 						{
 							description,
-							image: image_preview_url,
+							image: image_original_url,
 							name
 						},
 						true


### PR DESCRIPTION
This PR changes the image we're using to display collectibles to use the original collectible url.