### PR TITLE
bugfix: add collectible original image

### DIFF
--- a/src/AssetsController.test.ts
+++ b/src/AssetsController.test.ts
@@ -57,7 +57,7 @@ describe('AssetsController', () => {
 			() => ({
 				body: JSON.stringify({
 					description: 'Description',
-					image_preview_url: 'url',
+					image_original_url: 'url',
 					name: 'Name'
 				})
 			}),
@@ -68,7 +68,7 @@ describe('AssetsController', () => {
 			() => ({
 				body: JSON.stringify({
 					description: 'Kudos Description',
-					image_preview_url: 'Kudos url',
+					image_original_url: 'Kudos url',
 					name: 'Kudos Name'
 				})
 			}),

--- a/src/AssetsController.ts
+++ b/src/AssetsController.ts
@@ -6,6 +6,7 @@ import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 import { safelyExecute, handleFetch, validateTokenToWatch } from './util';
 import { EventEmitter } from 'events';
+import { ApiCollectibleResponse } from './AssetsDetectionController';
 
 const { toChecksumAddress } = require('ethereumjs-util');
 const Mutex = require('await-semaphore').Mutex;
@@ -213,15 +214,15 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
 		tokenId: number
 	): Promise<CollectibleInformation> {
 		const tokenURI = this.getCollectibleApi(contractAddress, tokenId);
-		let collectibleInformation;
+		let collectibleInformation: ApiCollectibleResponse;
 		/* istanbul ignore if */
 		if (this.openSeaApiKey) {
 			collectibleInformation = await handleFetch(tokenURI, { headers: { 'X-API-KEY': this.openSeaApiKey } });
 		} else {
 			collectibleInformation = await handleFetch(tokenURI);
 		}
-		const { name, description, image_preview_url } = collectibleInformation;
-		return { image: image_preview_url, name, description };
+		const { name, description, image_original_url } = collectibleInformation;
+		return { image: image_original_url, name, description };
 	}
 
 	/**


### PR DESCRIPTION
Doing QA of this previous PR https://github.com/MetaMask/gaba/pull/99, noticed that there was method without change. The original bug was solved (when auto detecting assets), but it was still there for manually added a collectible. Added types to make sure this won't happen again.