### PR TITLE
Bugfix: update exchange rates

### DIFF
--- a/src/CurrencyRateController.ts
+++ b/src/CurrencyRateController.ts
@@ -1,6 +1,7 @@
 import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from './BaseController';
 import { safelyExecute } from './util';
+const Mutex = require('await-semaphore').Mutex;
 
 /**
  * @type CurrencyRateConfig
@@ -41,6 +42,7 @@ export interface CurrencyRateState extends BaseState {
 export class CurrencyRateController extends BaseController<CurrencyRateConfig, CurrencyRateState> {
 	private activeCurrency = '';
 	private activeNativeCurrency = '';
+	private mutex = new Mutex();
 	private handle?: NodeJS.Timer;
 
 	private getPricingURL(currentCurrency: string, nativeCurrency: string) {
@@ -141,6 +143,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 		if (this.disabled || !this.activeCurrency || !this.activeNativeCurrency) {
 			return;
 		}
+		const releaseLock = await this.mutex.acquire();
 		const { conversionDate, conversionRate } = await this.fetchExchangeRate(
 			this.activeCurrency,
 			this.activeNativeCurrency
@@ -151,6 +154,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 			currentCurrency: this.activeCurrency,
 			nativeCurrency: this.activeNativeCurrency
 		});
+		releaseLock();
 		return this.state;
 	}
 }

--- a/tests/CurrencyRateController.test.ts
+++ b/tests/CurrencyRateController.test.ts
@@ -32,16 +32,17 @@ describe('CurrencyRateController', () => {
 
 	it('should poll and update rate in the right interval', () => {
 		return new Promise((resolve) => {
-			const mock = stub(CurrencyRateController.prototype, 'fetchExchangeRate');
-			// tslint:disable-next-line: no-unused-expression
-			new CurrencyRateController({ interval: 10 });
-			expect(mock.called).toBe(true);
-			expect(mock.calledTwice).toBe(false);
+			const controller = new CurrencyRateController({ interval: 100 });
+			const mock = stub(controller, 'fetchExchangeRate').resolves({});
+			setTimeout(() => {
+				expect(mock.called).toBe(true);
+				expect(mock.calledTwice).toBe(false);
+			}, 1);
 			setTimeout(() => {
 				expect(mock.calledTwice).toBe(true);
 				mock.restore();
 				resolve();
-			}, 15);
+			}, 150);
 		});
 	});
 
@@ -49,7 +50,7 @@ describe('CurrencyRateController', () => {
 		const controller = new CurrencyRateController({
 			interval: 10
 		});
-		controller.fetchExchangeRate = stub();
+		controller.fetchExchangeRate = stub().resolves({});
 		controller.disabled = true;
 		await controller.updateExchangeRate();
 		expect((controller.fetchExchangeRate as any).called).toBe(false);


### PR DESCRIPTION
This PR adds a semaphore to `updateExchangeRate`, this was causing wrong conversion rates.
If the app sets native currency as ETH and then DAI, `fetchExchangeRate` could finish first for DAI, producing that ETH conversion rate is set to state because it finished later, even though it was called first.