### PR TITLE
Bugfix: token rates

### DIFF
--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -165,12 +165,12 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 		const newContractExchangeRates: { [address: string]: number } = {};
 		const { nativeCurrency } = this.config;
 		const pairs = this.tokenList.map((token) => token.address).join(',');
-		const query = `contract_addresses=${pairs}&vs_currencies=${nativeCurrency}`;
+		const query = `contract_addresses=${pairs}&vs_currencies=${nativeCurrency.toLowerCase()}`;
 		const prices = await this.fetchExchangeRate(query);
 		this.tokenList.forEach((token) => {
 			const address = toChecksumAddress(token.address);
 			const price = prices[token.address.toLowerCase()];
-			newContractExchangeRates[address] = price ? price[nativeCurrency] : 0;
+			newContractExchangeRates[address] = price ? price[nativeCurrency.toLowerCase()] : 0;
 		});
 		this.update({ contractExchangeRates: newContractExchangeRates });
 	}


### PR DESCRIPTION
This pr fixes a bug introduced in https://github.com/MetaMask/gaba/commit/6499e74a64523265c2cc614ead1c95011abc394e 

Changing `nativeCurrency` of `CurrencyRateController` to `ETH` (capital letters) broke the query to CoinGecko. This pr makes sure that native currency is always sent in lower case.