### PR TITLE
Add declaration files for TypeScript consumers

### DIFF
--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -7,6 +7,8 @@ import { AssetsContractController } from './AssetsContractController';
 
 const { BN } = require('ethereumjs-util');
 
+export { BN };
+
 /**
  * @type TokenBalancesConfig
  *

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
 	"compilerOptions": {
+		"declaration": true,
+		"declarationDir": "dist",
 		"experimentalDecorators": true,
 		"importHelpers": false,
 		"module": "commonjs",


### PR DESCRIPTION
This PR updates the TypeScript config to produce type declaration files into the `dist` folder, allowing TypeScript consumers to properly get type information. I've exported `BN` from `TokenBalancesController.ts` as it's used in the `TokenBalancesState`, which itself is public.