### PR TITLE
Add npm-shrinkwrap settings to the EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[{package,package-lock}.json]
+[{package,package-lock,npm-shrinkwrap}.json]
 indent_size = 2
 indent_style = space


### PR DESCRIPTION
This PR adds `npm-shrinkwrap.json` to the EditorConfig file alongside the `package*.json` files.