### PR TITLE
Use job-based Travis config, test CI install

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,7 @@ trim_trailing_whitespace = false
 [{package,package-lock}.json]
 indent_size = 2
 indent_style = space
+
+[.travis.yml]
+indent_size = 2
+indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,25 @@
 language: node_js
 node_js: "8"
-install:
-- travis_retry npm install -g codecov
-- travis_retry npm install
-script:
-- npm run format
-- npm run lint
-- npm run test
-- npm run build
-- npm run doc
-- codecov
+jobs:
+  include:
+    - stage: "Tests & coverage"
+      before_install:
+        - travis_retry npm install -g codecov
+      install:
+        - travis_retry npm install
+      script:
+        - npm run format
+        - npm run lint
+        - npm run test
+        - npm run build
+        - npm run doc
+        - codecov
+    - stage: "Tests & coverage"
+      install:
+        - npm ci
+      cache:
+        directories:
+          - "$HOME/.npm"
 deploy:
   provider: pages
   skip-cleanup: true


### PR DESCRIPTION
This PR updates the Travis config to:

1. Use the job-based config<sup>[\[1\]](https://docs.travis-ci.com/user/build-stages/)</sup>
2. Test `npm ci` in addition to `npm install`