### PR TITLE
Remove all extraneous test output

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -125,7 +125,10 @@ export async function safelyExecute(operation: () => Promise<any>, logError = fa
 	try {
 		return await operation();
 	} catch (error) {
-		logError && console.error(error);
+		/* istanbul ignore next */
+		if (logError) {
+			console.error(error);
+		}
 		retry && retry(error);
 	}
 }

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -65,7 +65,7 @@ describe('util', () => {
 					() => {
 						throw new Error('ahh');
 					},
-					true,
+					false,
 					resolve
 				);
 			});


### PR DESCRIPTION
This PR removes extraneous test output, namely disabling logging of the error from the `utils#safelyExecute` test case.