### PR TITLE
Fail tx directly if sign method missing

### DIFF
--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -392,10 +392,12 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const transactionMeta = transactions[index];
 		const { from } = transactionMeta.transaction;
 
+		if (!this.sign) {
+			this.failTransaction(transactionMeta, new Error('No sign method defined.'));
+			return;
+		}
+
 		try {
-			if (!this.sign) {
-				throw new Error('No sign method defined.');
-			}
 			transactionMeta.status = 'approved';
 			transactionMeta.transaction.nonce = await this.query('getTransactionCount', [from, 'pending']);
 			transactionMeta.transaction.chainId = parseInt(currentNetworkID, undefined);


### PR DESCRIPTION
This PR removes the exception thrown when `this.sign` is falsy in the `TransactionController`'s `approveTransaction` method.

**Why is using exceptions as flow control not great?**

See also: [\[1\]][1], [\[2\]][2], [\[3\]][3], and [\[4\]][4]

  [1]:https://web.archive.org/web/20140430044213/http://c2.com/cgi-bin/wiki?DontUseExceptionsForFlowControl
  [2]:https://softwareengineering.stackexchange.com/q/189222/114526
  [3]:https://stackoverflow.com/q/729379/1267663
  [4]:https://stackoverflow.com/a/47016061/1267663

The case where `this.sign` is falsy isn't _exceptional_ and we know immediately how to handle it and what error message is associated with it. As such, we can immediately fail the tx and return early from the method.