### PR TITLE
bugfix: collectibles detection

### DIFF
--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -56,7 +56,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
 	private handle?: NodeJS.Timer;
 
 	private getOwnerCollectiblesApi(address: string) {
-		return `https://api.opensea.io/api/v1/assets?owner=${address}`;
+		return `https://api.opensea.io/api/v1/assets?owner=${address}&limit=300`;
 	}
 
 	private async getOwnerCollectibles() {

--- a/tests/AssetsDetectionController.test.ts
+++ b/tests/AssetsDetectionController.test.ts
@@ -47,7 +47,7 @@ describe('AssetsDetectionController', () => {
 		);
 
 		get(
-			OPEN_SEA_API + 'assets?owner=0x2',
+			OPEN_SEA_API + 'assets?owner=0x2&limit=300',
 			() => ({
 				body: JSON.stringify({
 					assets: [
@@ -67,7 +67,7 @@ describe('AssetsDetectionController', () => {
 		);
 
 		getOnce(
-			OPEN_SEA_API + 'assets?owner=0x1',
+			OPEN_SEA_API + 'assets?owner=0x1&limit=300',
 			() => ({
 				body: JSON.stringify({
 					assets: [
@@ -126,7 +126,7 @@ describe('AssetsDetectionController', () => {
 		);
 
 		getOnce(
-			OPEN_SEA_API + 'assets?owner=0x1',
+			OPEN_SEA_API + 'assets?owner=0x1&limit=300',
 			() => ({
 				body: JSON.stringify({
 					assets: [
@@ -352,7 +352,7 @@ describe('AssetsDetectionController', () => {
 		);
 
 		getOnce(
-			OPEN_SEA_API + 'assets?owner=0x1',
+			OPEN_SEA_API + 'assets?owner=0x1&limit=300',
 			() => ({
 				body: JSON.stringify({
 					assets: [


### PR DESCRIPTION
There is a limit for detecting collectibles that defaults to 20, for users with more than 20 collectibles it won't show all of their collectibles. I updated the limit to 300, that's the maximum limit we can get.