### PR TITLE
Update to ethereumjs-util@6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2494,6 +2494,22 @@
         "json-rpc-engine": "^3.6.0",
         "pify": "^2.3.0",
         "tape": "^4.6.3"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
       }
     },
     "eth-contract-metadata": {
@@ -2515,6 +2531,20 @@
         "xtend": "^4.0.1"
       },
       "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
         "events": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -2552,6 +2582,22 @@
         "json-stable-stringify": "^1.0.1",
         "promise-to-callback": "^1.0.0",
         "tape": "^4.6.3"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
       }
     },
     "eth-keyring-controller": {
@@ -2629,6 +2675,20 @@
               }
             }
           }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
         }
       }
     },
@@ -2692,6 +2752,20 @@
               }
             }
           }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
         }
       }
     },
@@ -2708,6 +2782,20 @@
         "xtend": "^4.0.1"
       },
       "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
         "events": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -2730,6 +2818,22 @@
         "ethereumjs-util": "^5.0.1",
         "ethereumjs-vm": "^2.6.0",
         "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
       }
     },
     "ethereum-common": {
@@ -2770,6 +2874,22 @@
         "ethereumjs-util": "^5.0.0",
         "rlp": "^2.0.0",
         "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
       }
     },
     "ethereumjs-block": {
@@ -2782,6 +2902,22 @@
         "ethereumjs-tx": "^1.2.2",
         "ethereumjs-util": "^5.0.0",
         "merkle-patricia-tree": "^2.1.2"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
       }
     },
     "ethereumjs-common": {
@@ -2802,6 +2938,20 @@
           "version": "0.0.18",
           "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
           "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
         }
       }
     },
@@ -6309,6 +6459,20 @@
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
         }
       }
     },
@@ -9073,6 +9237,20 @@
                 "secp256k1": "^3.0.1"
               }
             }
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2806,13 +2806,13 @@
       }
     },
     "ethereumjs-util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+      "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
       "requires": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
-        "ethjs-util": "^0.1.3",
+        "ethjs-util": "0.1.6",
         "keccak": "^1.0.2",
         "rlp": "^2.0.0",
         "safe-buffer": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eth-phishing-detect": "^1.1.13",
     "eth-query": "^2.1.2",
     "eth-sig-util": "^2.1.0",
-    "ethereumjs-util": "^5.2.0",
+    "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "0.6.0",
     "ethjs-query": "^0.3.8",
     "human-standard-collectible-abi": "^1.0.2",

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -1,4 +1,5 @@
 import 'isomorphic-fetch';
+import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import NetworkController, { NetworkType } from '../network/NetworkController';
@@ -8,7 +9,6 @@ import { safelyExecute, handleFetch, validateTokenToWatch } from '../util';
 import { EventEmitter } from 'events';
 import { ApiCollectibleResponse } from './AssetsDetectionController';
 
-const { toChecksumAddress } = require('ethereumjs-util');
 const Mutex = require('await-semaphore').Mutex;
 const random = require('uuid/v1');
 

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -1,4 +1,5 @@
 import 'isomorphic-fetch';
+import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import AssetsController from './AssetsController';
 import NetworkController from '../network/NetworkController';
@@ -9,7 +10,6 @@ import { Token } from './TokenRatesController';
 import { NetworkType } from '../network/NetworkController';
 
 const contractMap = require('eth-contract-metadata');
-const { toChecksumAddress } = require('ethereumjs-util');
 const DEFAULT_INTERVAL = 180000;
 const MAINNET = 'mainnet';
 

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -1,9 +1,9 @@
 import 'isomorphic-fetch';
+import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import AssetsController from './AssetsController';
 import { safelyExecute } from '../util';
 import CurrencyRateController from './CurrencyRateController';
-const { toChecksumAddress } = require('ethereumjs-util');
 
 /**
  * @type CoinGeckoResponse

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -1,11 +1,11 @@
 import 'isomorphic-fetch';
+import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState, Listener } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import { Transaction } from '../transaction/TransactionController';
 import { PersonalMessageParams } from '../message-manager/PersonalMessageManager';
 import { TypedMessageParams } from '../message-manager/TypedMessageManager';
 const sigUtil = require('eth-sig-util');
-const { toChecksumAddress } = require('ethereumjs-util');
 const Keyring = require('eth-keyring-controller');
 const Mutex = require('await-semaphore').Mutex;
 const Wallet = require('ethereumjs-wallet');

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import NetworkController from '../network/NetworkController';
 import {
@@ -14,7 +15,7 @@ const MethodRegistry = require('eth-method-registry');
 const EthQuery = require('eth-query');
 const Transaction = require('ethereumjs-tx');
 const random = require('uuid/v1');
-const { addHexPrefix, bufferToHex, BN } = require('ethereumjs-util');
+const { BN } = require('ethereumjs-util');
 const Mutex = require('await-semaphore').Mutex;
 
 /**

--- a/src/user/AddressBookController.ts
+++ b/src/user/AddressBookController.ts
@@ -1,6 +1,6 @@
+import { isValidAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 const extend = require('xtend');
-const { isValidAddress } = require('ethereumjs-util');
 
 /**
  * @type ContactEntry

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -1,7 +1,6 @@
+import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { ContactEntry } from '../user/AddressBookController';
-
-const { toChecksumAddress } = require('ethereumjs-util');
 
 /**
  * Custom RPC network information

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,4 @@
+import { addHexPrefix, isValidAddress, bufferToHex } from 'ethereumjs-util';
 import { Transaction } from './transaction/TransactionController';
 import { PersonalMessageParams } from './message-manager/PersonalMessageManager';
 import { TypedMessageParams } from './message-manager/TypedMessageManager';
@@ -5,7 +6,7 @@ import { Token } from './assets/TokenRatesController';
 
 const sigUtil = require('eth-sig-util');
 const jsonschema = require('jsonschema');
-const { addHexPrefix, BN, isValidAddress, stripHexPrefix, bufferToHex } = require('ethereumjs-util');
+const { BN, stripHexPrefix } = require('ethereumjs-util');
 const hexRe = /^[0-9A-Fa-f]+$/g;
 
 const NORMALIZERS: { [param in keyof Transaction]: any } = {

--- a/tests/KeyringController.test.ts
+++ b/tests/KeyringController.test.ts
@@ -1,9 +1,9 @@
+import * as ethUtil from 'ethereumjs-util';
 import KeyringController, { Keyring } from '../src/keyring/KeyringController';
 import PreferencesController from '../src/user/PreferencesController';
 import ComposableController from '../src/ComposableController';
 import { KeyringConfig } from '../src/keyring/KeyringController';
 import { stub } from 'sinon';
-const ethUtil = require('ethereumjs-util');
 const mockEncryptor: any = require('../node_modules/eth-keyring-controller/test/lib/mock-encryptor.js');
 const Transaction = require('ethereumjs-tx');
 


### PR DESCRIPTION
This PR updates the direct `ethereumjs-util` dependency to v6, which includes TypeScript definitions. There are no relevant breaking changes to GABA's _direct_ usage:<sup>[\[1\]][1]</sup>

> - [BREAKING] Fixed signature to comply with Geth and Parity in `toRpcSig()` changing 
  `v` from 0/1 to 27/28, this changes the resulting signature buffer, see PR [#139](https://github.com/ethereumjs/ethereumjs-util/pull/139)
> - [BREAKING] Remove deprecated `sha3`-named constants and methods (see `v5.2.0` release),
  see PR [#154](https://github.com/ethereumjs/ethereumjs-util/pull/154)

I've changed the places where `ethereumjs-util` are being `require`'d to use TypeScript imports where possible (minus `BN` whose types don't match the usages and #141).

  [1]:https://github.com/ethereumjs/ethereumjs-util/releases/tag/v6.0.0