### PR TITLE
Update AddressBookController API

### DIFF
--- a/src/user/AddressBookController.ts
+++ b/src/user/AddressBookController.ts
@@ -1,6 +1,5 @@
+const { isValidAddress, toChecksumAddress } = require('ethereumjs-util');
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-const extend = require('xtend');
-const { isValidAddress } = require('ethereumjs-util');
 
 /**
  * @type ContactEntry
@@ -79,8 +78,15 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 	 * @param address - Recipient address to delete
 	 */
 	delete(address: string) {
-		delete this.state.addressBook[address];
-		this.update({ addressBook: { ...this.state.addressBook } });
+		const normalizedAddress = toChecksumAddress(address);
+		if (!isValidAddress(normalizedAddress) || this.state.addressBook[normalizedAddress] === undefined) {
+			return false;
+		}
+
+		const addressBook: { [address: string]: AddressBookEntry } = Object.assign({}, this.state.addressBook);
+		delete addressBook[normalizedAddress];
+		this.update({ addressBook });
+		return true;
 	}
 
 	/**
@@ -96,7 +102,19 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 		if (!isValidAddress(address)) {
 			return false;
 		}
-		this.update({ addressBook: extend(this.state.addressBook, { [address]: { address, name, chainId, memo } }) });
+
+		this.update({
+			addressBook: {
+				...this.state.addressBook,
+				[toChecksumAddress(address)]: {
+					address,
+					chainId,
+					memo,
+					name
+				}
+			}
+		});
+
 		return true;
 	}
 }

--- a/tests/AddressBookController.test.ts
+++ b/tests/AddressBookController.test.ts
@@ -104,4 +104,43 @@ describe('AddressBookController', () => {
 		controller.clear();
 		expect(controller.state).toEqual({ addressBook: {} });
 	});
+
+	it('should return true to indicate an address book entry has been added', () => {
+		const controller = new AddressBookController();
+		expect(controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo')).toBeTruthy();
+	});
+
+	it('should return false to indicate an address book entry has NOT been added', () => {
+		const controller = new AddressBookController();
+		expect(controller.set('1337', 'foo')).toBeFalsy();
+	});
+
+	it('should return true to indicate an address book entry has been deleted', () => {
+		const controller = new AddressBookController();
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
+		expect(controller.delete('0x32Be343B94f860124dC4fEe278FDCBD38C102D88')).toBeTruthy();
+	});
+
+	it('should return false to indicate an address book entry has NOT been deleted', () => {
+		const controller = new AddressBookController();
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
+		expect(controller.delete('bar')).toBeFalsy();
+	});
+
+	it('should normalize addresses so adding a removing entries work across casings', () => {
+		const controller = new AddressBookController();
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
+		expect(controller.set('0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d', 'bar')).toBeTruthy();
+		controller.delete('0xC38BF1AD06EF69F0C04E29DBEB4152B4175F0A8D');
+		expect(controller.state).toEqual({
+			addressBook: {
+				'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+					address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+					chainId: 1,
+					memo: '',
+					name: 'foo'
+				}
+			}
+		});
+	});
 });


### PR DESCRIPTION
This PR updates the `AddressBookController` to make its API more consistent and intuitive with two changes:

1. Symmetry in the `add`/`delete` return values—both methods now return a boolean to indicate success
2. Normalize addresses to allow ensure that case differences in the addresses doesn't fail silently (also helped by pt. 1)