### PR TITLE
Fix import path for AddressBookController

### DIFF
--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -1,5 +1,5 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-import { ContactEntry } from '../user/AddressBookController';
+import { ContactEntry } from './AddressBookController';
 
 const { toChecksumAddress } = require('ethereumjs-util');
 


### PR DESCRIPTION
This PR fixes a small nitpick with the import for `AddressBookController` in the `PreferencesController`—the import path is navigating up and back into the same directory.