### PR TITLE
Remove deprecated Buffer constructor

### DIFF
--- a/tests/KeyringController.test.ts
+++ b/tests/KeyringController.test.ts
@@ -135,7 +135,7 @@ describe('KeyringController', () => {
 	});
 
 	it('should sign personal message', async () => {
-		const data = ethUtil.bufferToHex(new Buffer('Hello from test', 'utf8'));
+		const data = ethUtil.bufferToHex(Buffer.from('Hello from test', 'utf8'));
 		const account = initialState.keyrings[0].accounts[0];
 		const signature = await keyringController.signPersonalMessage({ data, from: account });
 		expect(signature).not.toBe('');


### PR DESCRIPTION
This PR fixes the following deprecation warning that appears when running the tests:

```
(node:83313) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```