### PR TITLE
Add EnsController

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2350,6 +2350,20 @@
               }
             }
           }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2229,6 +2229,22 @@
       "resolved": "https://registry.npmjs.org/eth-contract-metadata/-/eth-contract-metadata-1.9.2.tgz",
       "integrity": "sha512-2ycmqRQ9u4Tbpir7hwEKZ8Qjy1bc3KaiRBd/jkL8Xye9wqnYMpgaUK4UHPm1uTnCZZ+KoN0Mxg6kL9JILrYdhA=="
     },
+    "eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "requires": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
     "eth-hd-keyring": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eth-hd-keyring/-/eth-hd-keyring-2.0.0.tgz",
@@ -4162,6 +4178,21 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
       }
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "dependencies": {
     "await-semaphore": "^0.1.3",
     "eth-contract-metadata": "^1.9.1",
+    "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-infura": "^4.0.1",
     "eth-keyring-controller": "^5.0.1",
     "eth-method-registry": "1.1.0",

--- a/src/third-party/EnsController.ts
+++ b/src/third-party/EnsController.ts
@@ -105,11 +105,13 @@ export class EnsController extends BaseController<BaseConfig, EnsState> {
 	}
 
 	/**
-	 * Add or update an ENS entry by chainId and ensName
+	 * Add or update an ENS entry by chainId and ensName.
+	 *
+	 * A null address indicates that the ENS name does not resolve.
 	 *
 	 * @param chainId - Id of the associated chain
 	 * @param ensName - The ENS name
-	 * @param address - Associated address to add or update
+	 * @param address - Associated address (or null) to add or update
 	 *
 	 * @returns - Boolean indicating if the entry was set
 	 */

--- a/src/third-party/EnsController.ts
+++ b/src/third-party/EnsController.ts
@@ -1,0 +1,125 @@
+import BaseController, { BaseConfig, BaseState } from '../BaseController';
+import { isValidAddress, toChecksumAddress } from 'ethereumjs-util';
+
+/**
+ * @type EnsEntry
+ *
+ * ENS entry representation
+ *
+ * @property chainId - Id of the associated chain
+ * @property ensName - The ENS name
+ * @property address - Hex address with the ENS name
+ */
+export interface EnsEntry {
+	chainId: string;
+	ensName: string;
+	address: string | null;
+}
+
+/**
+ * @type EnsState
+ *
+ * ENS controller state
+ *
+ * @property ensEntries - Object of ENS entry objects
+ */
+export interface EnsState extends BaseState {
+	ensEntries: { [chainId: string]: { [ensName: string]: EnsEntry } };
+}
+
+/**
+ * Controller that manages a list ENS names and their resolved addresses
+ * by chainId
+ */
+export class EnsController extends BaseController<BaseConfig, EnsState> {
+	/**
+	 * Name of this controller used during composition
+	 */
+	name = 'EnsController';
+
+	/**
+	 * Creates an EnsController instance
+	 *
+	 * @param config - Initial options used to configure this controller
+	 * @param state - Initial state to set on this controller
+	 */
+	constructor(config?: Partial<BaseConfig>, state?: Partial<EnsState>) {
+		super(config, state);
+
+		this.defaultState = { ensEntries: {} };
+
+		this.initialize();
+	}
+
+	/**
+	 * Remove all chain Ids and ENS entries from state
+	 */
+	clear() {
+		this.update({ ensEntries: {} });
+	}
+
+	/**
+	 * Remove a contract entry by address
+	 *
+	 * @param chainId - Parent chain of the ENS entry to delete
+	 * @param ensName - Name of the ENS entry to delete
+	 */
+	delete(chainId: string, ensName: string) {
+		if (!this.state.ensEntries[chainId] || !this.state.ensEntries[chainId][ensName]) {
+			return false;
+		}
+
+		const ensEntries = Object.assign({}, this.state.ensEntries);
+		delete ensEntries[chainId][ensName];
+
+		if (Object.keys(ensEntries[chainId]).length === 0) {
+			delete ensEntries[chainId];
+		}
+
+		this.update({ ensEntries });
+		return true;
+	}
+
+	/**
+	 * Add or update an ENS entry by chainId and ensName
+	 *
+	 * @param chainId - Id of the associated chain
+	 * @param ensName - The ENS name
+	 * @param address - Associated address to add or update
+	 * @returns - Boolean indicating whether the entry was set
+	 */
+	set(chainId: string, ensName: string, address: string | null): boolean {
+		if (
+			!Number.isInteger(Number.parseInt(chainId, 10)) ||
+			!ensName ||
+			typeof ensName !== 'string' ||
+			(address && !isValidAddress(address))
+		) {
+			throw new Error(`Invalid ENS entry: { chainId:${chainId}, ensName:${ensName}, address:${address}}`);
+		}
+
+		const normalizedAddress = address ? toChecksumAddress(address) : null;
+		const subState = this.state.ensEntries[chainId];
+
+		if (subState && subState[ensName] && subState[ensName].address === normalizedAddress) {
+			return false;
+		}
+
+		this.update({
+			ensEntries: {
+				...this.state.ensEntries,
+				[chainId]: {
+					...this.state.ensEntries[chainId],
+					[ensName]: {
+						address: normalizedAddress,
+						chainId,
+						ensName
+					}
+				}
+			}
+		});
+		return true;
+	}
+}
+
+export default EnsController;

--- a/src/user/AddressBookController.ts
+++ b/src/user/AddressBookController.ts
@@ -1,5 +1,5 @@
 import { isValidAddress, toChecksumAddress } from 'ethereumjs-util';
-import { isValidEnsName } from '../util';
+import { normalizeEnsName } from '../util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
 /**
@@ -112,18 +112,26 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 			return false;
 		}
 
+		const entry = {
+			address,
+			chainId,
+			isEns: false,
+			memo,
+			name
+		};
+
+		const ensName = normalizeEnsName(name);
+		if (ensName) {
+			entry.name = ensName;
+			entry.isEns = true;
+		}
+
 		this.update({
 			addressBook: {
 				...this.state.addressBook,
 				[chainId]: {
 					...this.state.addressBook[chainId],
-					[address]: {
-						address,
-						chainId,
-						isEns: isValidEnsName(name),
-						memo,
-						name
-					}
+					[address]: entry
 				}
 			}
 		});

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,7 @@ import { Token } from './assets/TokenRatesController';
 const sigUtil = require('eth-sig-util');
 const jsonschema = require('jsonschema');
 const { BN, stripHexPrefix } = require('ethereumjs-util');
+const ensNamehash = require('eth-ens-namehash');
 const hexRe = /^[0-9A-Fa-f]+$/g;
 
 const NORMALIZERS: { [param in keyof Transaction]: any } = {
@@ -320,9 +321,26 @@ export async function timeoutFetch(url: string, options?: RequestInit, timeout: 
 	]);
 }
 
-export function isValidEnsName(ensName: string) {
-	const regex = /^.{7,}\.(eth|test)$/;
-	return regex.test(ensName);
+/**
+ * Normalizes the given ENS name.
+ *
+ * @param {string} ensName - The ENS name
+ *
+ * @returns - the normalized ENS name string
+ */
+export function normalizeEnsName(ensName: string): string | null {
+	if (ensName && typeof ensName === 'string') {
+		try {
+			const normalized = ensNamehash.normalize(ensName.trim());
+			// change 7 in regex to 3 when shorter ENS domains are live
+			if (normalized.match(/^(([\w\d]+)\.)*[\w\d]{7,}\.(eth|test)$/)) {
+				return normalized;
+			}
+		} catch (_) {
+			// do nothing
+		}
+	}
+	return null;
 }
 
 export default {
@@ -333,7 +351,6 @@ export default {
 	hexToBN,
 	hexToText,
 	isSmartContractCode,
-	isValidEnsName,
 	normalizeTransaction,
 	safelyExecute,
 	timeoutFetch,

--- a/src/util.ts
+++ b/src/util.ts
@@ -332,8 +332,9 @@ export function normalizeEnsName(ensName: string): string | null {
 	if (ensName && typeof ensName === 'string') {
 		try {
 			const normalized = ensNamehash.normalize(ensName.trim());
-			// change 7 in regex to 3 when shorter ENS domains are live
-			if (normalized.match(/^(([\w\d]+)\.)*[\w\d]{7,}\.(eth|test)$/)) {
+			// this regex is only sufficient with the above call to ensNamehash.normalize
+			// TODO: change 7 in regex to 3 when shorter ENS domains are live
+			if (normalized.match(/^(([\w\d\-]+)\.)*[\w\d\-]{7,}\.(eth|test)$/)) {
 				return normalized;
 			}
 		} catch (_) {

--- a/tests/ComposableController.test.ts
+++ b/tests/ComposableController.test.ts
@@ -1,5 +1,6 @@
 import { stub } from 'sinon';
 import AddressBookController from '../src/user/AddressBookController';
+import EnsController from '../src/third-party/EnsController';
 import ComposableController from '../src/ComposableController';
 import PreferencesController from '../src/user/PreferencesController';
 import TokenRatesController from '../src/assets/TokenRatesController';
@@ -14,6 +15,7 @@ describe('ComposableController', () => {
 			new AddressBookController(),
 			new AssetsController(),
 			new AssetsContractController(),
+			new EnsController(),
 			new CurrencyRateController(),
 			new NetworkController(),
 			new PreferencesController(),
@@ -39,6 +41,9 @@ describe('ComposableController', () => {
 				currentCurrency: 'usd',
 				nativeCurrency: 'ETH'
 			},
+			EnsController: {
+				ensEntries: {}
+			},
 			NetworkController: {
 				network: 'loading',
 				provider: { type: 'mainnet' }
@@ -60,6 +65,7 @@ describe('ComposableController', () => {
 			new AddressBookController(),
 			new AssetsController(),
 			new AssetsContractController(),
+			new EnsController(),
 			new CurrencyRateController(),
 			new NetworkController(),
 			new PreferencesController(),
@@ -76,6 +82,7 @@ describe('ComposableController', () => {
 			conversionDate: 0,
 			conversionRate: 0,
 			currentCurrency: 'usd',
+			ensEntries: {},
 			featureFlags: {},
 			frequentRpcList: [],
 			identities: {},
@@ -98,6 +105,7 @@ describe('ComposableController', () => {
 			new AssetsController(),
 			new AssetsContractController(),
 			new CurrencyRateController(),
+			new EnsController(),
 			new NetworkController(),
 			new PreferencesController(),
 			new TokenRatesController()
@@ -127,6 +135,7 @@ describe('ComposableController', () => {
 			conversionDate: 0,
 			conversionRate: 0,
 			currentCurrency: 'usd',
+			ensEntries: {},
 			featureFlags: {},
 			frequentRpcList: [],
 			identities: {},

--- a/tests/EnsController.test.ts
+++ b/tests/EnsController.test.ts
@@ -1,0 +1,219 @@
+import { toChecksumAddress } from 'ethereumjs-util';
+
+import EnsController from '../src/third-party/EnsController';
+
+const address1 = '0x32Be343B94f860124dC4fEe278FDCBD38C102D88';
+const address2 = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+const address3 = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359';
+const name1 = 'foo.eth';
+const name2 = 'bar.eth';
+
+const address1Checksum = toChecksumAddress(address1);
+const address2Checksum = toChecksumAddress(address2);
+const address3Checksum = toChecksumAddress(address3);
+
+describe('EnsController', () => {
+	it('should set default state', () => {
+		const controller = new EnsController();
+		expect(controller.state).toEqual({ ensEntries: {} });
+	});
+
+	it('should add a new ENS entry and return true', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name1]: {
+						address: address1Checksum,
+						chainId: '1',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should add a new ENS entry with null address and return true', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, null)).toBeTruthy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name1]: {
+						address: null,
+						chainId: '1',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should update an ENS entry and return true', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.set('1', name1, address2)).toBeTruthy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name1]: {
+						address: address2Checksum,
+						chainId: '1',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should update an ENS entry with null address and return true', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.set('1', name1, null)).toBeTruthy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name1]: {
+						address: null,
+						chainId: '1',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should not update an ENS entry if the address is the same (valid address) and return false', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.set('1', name1, address1)).toBeFalsy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name1]: {
+						address: address1Checksum,
+						chainId: '1',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should not update an ENS entry if the address is the same (null) and return false', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, null)).toBeTruthy();
+		expect(controller.set('1', name1, null)).toBeFalsy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name1]: {
+						address: null,
+						chainId: '1',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should add multiple ENS entries and update without side effects', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.set('1', name2, address2)).toBeTruthy();
+		expect(controller.set('2', name1, address1)).toBeTruthy();
+		expect(controller.set('1', name1, address3)).toBeTruthy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name1]: {
+						address: address3Checksum,
+						chainId: '1',
+						ensName: name1
+					},
+					[name2]: {
+						address: address2Checksum,
+						chainId: '1',
+						ensName: name2
+					}
+				},
+				2: {
+					[name1]: {
+						address: address1Checksum,
+						chainId: '2',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should throw on attempt to set invalid ENS entry', () => {
+		const controller = new EnsController();
+		expect(() => {
+			controller.set('1', '1337', 'foo');
+		}).toThrowError();
+		expect(controller.state).toEqual({ ensEntries: {} });
+	});
+
+	it('should remove an ENS entry and return true', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.delete('1', name1)).toBeTruthy();
+		expect(controller.state).toEqual({ ensEntries: {} });
+	});
+
+	it('should return false if an ENS entry was NOT deleted', () => {
+		const controller = new EnsController();
+		controller.set('1', name1, address1);
+		expect(controller.delete('1', 'bar')).toBeFalsy();
+		expect(controller.delete('2', 'bar')).toBeFalsy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name1]: {
+						address: address1Checksum,
+						chainId: '1',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should add multiple ENS entries and remove without side effects', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.set('1', name2, address2)).toBeTruthy();
+		expect(controller.set('2', name1, address1)).toBeTruthy();
+		expect(controller.delete('1', name1)).toBeTruthy();
+		expect(controller.state).toEqual({
+			ensEntries: {
+				1: {
+					[name2]: {
+						address: address2Checksum,
+						chainId: '1',
+						ensName: name2
+					}
+				},
+				2: {
+					[name1]: {
+						address: address1Checksum,
+						chainId: '2',
+						ensName: name1
+					}
+				}
+			}
+		});
+	});
+
+	it('should clear all ENS entries', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.set('1', name2, address2)).toBeTruthy();
+		expect(controller.set('2', name1, address1)).toBeTruthy();
+		controller.clear();
+		expect(controller.state).toEqual({ ensEntries: {} });
+	});
+});

--- a/tests/EnsController.test.ts
+++ b/tests/EnsController.test.ts
@@ -5,8 +5,8 @@ import EnsController from '../src/third-party/EnsController';
 const address1 = '0x32Be343B94f860124dC4fEe278FDCBD38C102D88';
 const address2 = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
 const address3 = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359';
-const name1 = 'foo.eth';
-const name2 = 'bar.eth';
+const name1 = 'foobarb.eth';
+const name2 = 'bazbarb.eth';
 
 const address1Checksum = toChecksumAddress(address1);
 const address2Checksum = toChecksumAddress(address2);
@@ -149,10 +149,48 @@ describe('EnsController', () => {
 		});
 	});
 
-	it('should throw on attempt to set invalid ENS entry', () => {
+	it('should get ENS entry by chainId and ensName', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.get('1', name1)).toEqual({
+			address: address1Checksum,
+			chainId: '1',
+			ensName: name1
+		});
+	});
+
+	it('should return null when getting nonexistent name', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.get('1', name2)).toEqual(null);
+	});
+
+	it('should return null when getting nonexistent chainId', () => {
+		const controller = new EnsController();
+		expect(controller.set('1', name1, address1)).toBeTruthy();
+		expect(controller.get('2', name1)).toEqual(null);
+	});
+
+	it('should throw on attempt to set invalid ENS entry: chainId', () => {
 		const controller = new EnsController();
 		expect(() => {
-			controller.set('1', '1337', 'foo');
+			controller.set('a', name1, address1);
+		}).toThrowError();
+		expect(controller.state).toEqual({ ensEntries: {} });
+	});
+
+	it('should throw on attempt to set invalid ENS entry: ENS name', () => {
+		const controller = new EnsController();
+		expect(() => {
+			controller.set('1', 'foo.eth', address1);
+		}).toThrowError();
+		expect(controller.state).toEqual({ ensEntries: {} });
+	});
+
+	it('should throw on attempt to set invalid ENS entry: address', () => {
+		const controller = new EnsController();
+		expect(() => {
+			controller.set('1', name1, 'foo');
 		}).toThrowError();
 		expect(controller.state).toEqual({ ensEntries: {} });
 	});

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -454,14 +454,56 @@ describe('util', () => {
 			expect(error.message).toBe('timeout');
 		});
 	});
-	describe('isValidEnsName', () => {
-		it('should return if the ens name is valid by current standards', async () => {
-			const valid = util.isValidEnsName('metamask.eth');
-			expect(valid).toBeTruthy();
+
+	describe('normalizeEnsName', () => {
+		it('should normalize with valid 2LD', async () => {
+			const valid = util.normalizeEnsName('metamask.eth');
+			expect(valid).toEqual('metamask.eth');
 		});
-		it('should return if the ens name is invalid by current standards', async () => {
-			const invalid = util.isValidEnsName('me.eth');
-			expect(invalid).toBeFalsy();
+
+		it('should normalize with valid 2LD and "test" TLD', async () => {
+			const valid = util.normalizeEnsName('metamask.eth');
+			expect(valid).toEqual('metamask.eth');
+		});
+
+		it('should normalize with valid 2LD and 3LD', async () => {
+			const valid = util.normalizeEnsName('a.metamask.eth');
+			expect(valid).toEqual('a.metamask.eth');
+		});
+
+		it('should return null with invalid 2LD', async () => {
+			const invalid = util.normalizeEnsName('me.eth');
+			expect(invalid).toEqual(null);
+		});
+
+		it('should return null with valid 2LD and invalid 3LD', async () => {
+			const invalid = util.normalizeEnsName('@foo.metamask.eth');
+			expect(invalid).toEqual(null);
+		});
+
+		it('should return null with invalid 2LD and valid 3LD', async () => {
+			const invalid = util.normalizeEnsName('foo.barbaz.eth');
+			expect(invalid).toEqual(null);
+		});
+
+		it('should return null with invalid TLD', async () => {
+			const invalid = util.normalizeEnsName('a.metamask.com');
+			expect(invalid).toEqual(null);
+		});
+
+		it('should return null with repeated periods', async () => {
+			const invalid = util.normalizeEnsName('foo.metamask..eth');
+			expect(invalid).toEqual(null);
+		});
+
+		it('should return null with repeated periods', async () => {
+			const invalid = util.normalizeEnsName('foo..metamask.eth');
+			expect(invalid).toEqual(null);
+		});
+
+		it('should return null with empty string', async () => {
+			const invalid = util.normalizeEnsName('');
+			expect(invalid).toEqual(null);
 		});
 	});
 });

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -457,27 +457,57 @@ describe('util', () => {
 
 	describe('normalizeEnsName', () => {
 		it('should normalize with valid 2LD', async () => {
-			const valid = util.normalizeEnsName('metamask.eth');
+			let valid = util.normalizeEnsName('metamask.eth');
 			expect(valid).toEqual('metamask.eth');
+			valid = util.normalizeEnsName('foobar1.eth');
+			expect(valid).toEqual('foobar1.eth');
+			valid = util.normalizeEnsName('foo-bar.eth');
+			expect(valid).toEqual('foo-bar.eth');
+			valid = util.normalizeEnsName('1-foo-bar.eth');
+			expect(valid).toEqual('1-foo-bar.eth');
 		});
 
 		it('should normalize with valid 2LD and "test" TLD', async () => {
-			const valid = util.normalizeEnsName('metamask.eth');
-			expect(valid).toEqual('metamask.eth');
+			const valid = util.normalizeEnsName('metamask.test');
+			expect(valid).toEqual('metamask.test');
 		});
 
 		it('should normalize with valid 2LD and 3LD', async () => {
-			const valid = util.normalizeEnsName('a.metamask.eth');
+			let valid = util.normalizeEnsName('a.metamask.eth');
 			expect(valid).toEqual('a.metamask.eth');
+			valid = util.normalizeEnsName('aa.metamask.eth');
+			expect(valid).toEqual('aa.metamask.eth');
+			valid = util.normalizeEnsName('a-a.metamask.eth');
+			expect(valid).toEqual('a-a.metamask.eth');
+			valid = util.normalizeEnsName('1-a.metamask.eth');
+			expect(valid).toEqual('1-a.metamask.eth');
+			valid = util.normalizeEnsName('1-2.metamask.eth');
+			expect(valid).toEqual('1-2.metamask.eth');
 		});
 
 		it('should return null with invalid 2LD', async () => {
-			const invalid = util.normalizeEnsName('me.eth');
+			let invalid = util.normalizeEnsName('me.eth');
+			expect(invalid).toEqual(null);
+			invalid = util.normalizeEnsName('metamask-.eth');
+			expect(invalid).toEqual(null);
+			invalid = util.normalizeEnsName('-metamask.eth');
+			expect(invalid).toEqual(null);
+			invalid = util.normalizeEnsName('@metamask.eth');
+			expect(invalid).toEqual(null);
+			invalid = util.normalizeEnsName('foobar.eth');
 			expect(invalid).toEqual(null);
 		});
 
 		it('should return null with valid 2LD and invalid 3LD', async () => {
-			const invalid = util.normalizeEnsName('@foo.metamask.eth');
+			let invalid = util.normalizeEnsName('-.metamask.eth');
+			expect(invalid).toEqual(null);
+			invalid = util.normalizeEnsName('abc-.metamask.eth');
+			expect(invalid).toEqual(null);
+			invalid = util.normalizeEnsName('-abc.metamask.eth');
+			expect(invalid).toEqual(null);
+			invalid = util.normalizeEnsName('.metamask.eth');
+			expect(invalid).toEqual(null);
+			invalid = util.normalizeEnsName('f@o.metamask.eth');
 			expect(invalid).toEqual(null);
 		});
 
@@ -492,12 +522,9 @@ describe('util', () => {
 		});
 
 		it('should return null with repeated periods', async () => {
-			const invalid = util.normalizeEnsName('foo.metamask..eth');
+			let invalid = util.normalizeEnsName('foo..metamask.eth');
 			expect(invalid).toEqual(null);
-		});
-
-		it('should return null with repeated periods', async () => {
-			const invalid = util.normalizeEnsName('foo..metamask.eth');
+			invalid = util.normalizeEnsName('foo.metamask..eth');
 			expect(invalid).toEqual(null);
 		});
 


### PR DESCRIPTION
Adds an `EnsController`. It keeps track of ENS name and their resolved addresses for the purpose of taking some useful action (e.g. warning the user in the UI).

Addresses and ENS names (see `util.ts:normalizeEnsName`) are normalized before being added. ENS name normalization added to address book controller as well.

ENS name normalization and verification should be updated in the extension if this change is integrated. That should amount to importing `normalizeEnsName` from `src/util.ts`.