### PR TITLE
update addressBook with entries by chainId

### DIFF
--- a/src/user/AddressBookController.ts
+++ b/src/user/AddressBookController.ts
@@ -112,11 +112,6 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 			return false;
 		}
 
-		let isEns = false;
-		if (isValidEnsName(name)) {
-			isEns = true;
-		}
-
 		this.update({
 			addressBook: {
 				...this.state.addressBook,
@@ -125,8 +120,7 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 					[address]: {
 						address,
 						chainId,
-						isEns,
-						// isEns: isValidEnsName(name),
+						isEns: isValidEnsName(name),
 						memo,
 						name
 					}

--- a/src/user/AddressBookController.ts
+++ b/src/user/AddressBookController.ts
@@ -1,4 +1,5 @@
 import { isValidAddress, toChecksumAddress } from 'ethereumjs-util';
+import { isValidEnsName } from '../util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
 /**
@@ -23,12 +24,14 @@ export interface ContactEntry {
  * @property name - Nickname associated with this address
  * @property chainId - Chain id identifies the current chain
  * @property memo - User's note about address
+ * @property isEns - is the entry an ENS name
  */
 export interface AddressBookEntry {
 	address: string;
 	name: string;
 	chainId: string;
 	memo: string;
+	isEns: boolean;
 }
 
 /**
@@ -109,6 +112,11 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 			return false;
 		}
 
+		let isEns = false;
+		if (isValidEnsName(name)) {
+			isEns = true;
+		}
+
 		this.update({
 			addressBook: {
 				...this.state.addressBook,
@@ -117,6 +125,8 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 					[address]: {
 						address,
 						chainId,
+						isEns,
+						// isEns: isValidEnsName(name),
 						memo,
 						name
 					}

--- a/src/user/AddressBookController.ts
+++ b/src/user/AddressBookController.ts
@@ -87,7 +87,6 @@ export class AddressBookController extends BaseController<BaseConfig, AddressBoo
 		delete addressBook[chainId][address];
 
 		if (Object.keys(addressBook[chainId]).length === 0) {
-			console.log('object.keys', addressBook[chainId]);
 			delete addressBook[chainId];
 		}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -320,6 +320,11 @@ export async function timeoutFetch(url: string, options?: RequestInit, timeout: 
 	]);
 }
 
+export function isValidEnsName(ensName: string) {
+	const regex = /^.{7,}\.(eth|test)$/;
+	return regex.test(ensName);
+}
+
 export default {
 	BNToHex,
 	fractionBN,
@@ -328,6 +333,7 @@ export default {
 	hexToBN,
 	hexToText,
 	isSmartContractCode,
+	isValidEnsName,
 	normalizeTransaction,
 	safelyExecute,
 	timeoutFetch,

--- a/tests/AddressBookController.test.ts
+++ b/tests/AddressBookController.test.ts
@@ -15,6 +15,7 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '1',
+						isEns: false,
 						memo: '',
 						name: 'foo'
 					}
@@ -32,6 +33,7 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '1',
+						isEns: false,
 						memo: 'account 1',
 						name: 'foo'
 					}
@@ -49,6 +51,7 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '2',
+						isEns: false,
 						memo: 'account 2',
 						name: 'foo'
 					}
@@ -68,6 +71,7 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '1',
+						isEns: false,
 						memo: 'account 2',
 						name: 'foo'
 					}
@@ -76,6 +80,7 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '2',
+						isEns: false,
 						memo: 'account 2',
 						name: 'foo'
 					}
@@ -94,6 +99,7 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '1',
+						isEns: false,
 						memo: '',
 						name: 'bar'
 					}
@@ -128,6 +134,7 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '1',
+						isEns: false,
 						memo: '',
 						name: 'foo'
 					}
@@ -147,14 +154,34 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '1',
+						isEns: false,
 						memo: '',
 						name: 'foo'
 					},
 					'0xC38bF1aD06ef69F0c04E29DBeB4152B4175f0A8D': {
 						address: '0xC38bF1aD06ef69F0c04E29DBeB4152B4175f0A8D',
 						chainId: '1',
+						isEns: false,
 						memo: '',
 						name: 'bar'
+					}
+				}
+			}
+		});
+	});
+
+	it('should correctly mark ens entries', () => {
+		const controller = new AddressBookController();
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'metamask.eth');
+		expect(controller.state).toEqual({
+			addressBook: {
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						isEns: true,
+						memo: '',
+						name: 'metamask.eth'
 					}
 				}
 			}
@@ -203,6 +230,7 @@ describe('AddressBookController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '1',
+						isEns: false,
 						memo: '',
 						name: 'foo'
 					}

--- a/tests/AddressBookController.test.ts
+++ b/tests/AddressBookController.test.ts
@@ -11,11 +11,13 @@ describe('AddressBookController', () => {
 		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
 		expect(controller.state).toEqual({
 			addressBook: {
-				'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-					address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-					chainId: 1,
-					memo: '',
-					name: 'foo'
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						memo: '',
+						name: 'foo'
+					}
 				}
 			}
 		});
@@ -23,14 +25,16 @@ describe('AddressBookController', () => {
 
 	it('should add a contact entry with chainId and memo', () => {
 		const controller = new AddressBookController();
-		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo', 1, 'account 1');
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo', '1', 'account 1');
 		expect(controller.state).toEqual({
 			addressBook: {
-				'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-					address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-					chainId: 1,
-					memo: 'account 1',
-					name: 'foo'
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						memo: 'account 1',
+						name: 'foo'
+					}
 				}
 			}
 		});
@@ -38,14 +42,43 @@ describe('AddressBookController', () => {
 
 	it('should add a contact entry with chainId and memo', () => {
 		const controller = new AddressBookController();
-		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo', 2, 'account 2');
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo', '2', 'account 2');
 		expect(controller.state).toEqual({
 			addressBook: {
-				'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-					address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-					chainId: 2,
-					memo: 'account 2',
-					name: 'foo'
+				2: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '2',
+						memo: 'account 2',
+						name: 'foo'
+					}
+				}
+			}
+		});
+	});
+
+	it('should add multiple contact entries with different chainIds', () => {
+		const controller = new AddressBookController();
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo', '1', 'account 2');
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo', '2', 'account 2');
+
+		expect(controller.state).toEqual({
+			addressBook: {
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						memo: 'account 2',
+						name: 'foo'
+					}
+				},
+				2: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '2',
+						memo: 'account 2',
+						name: 'foo'
+					}
 				}
 			}
 		});
@@ -57,11 +90,13 @@ describe('AddressBookController', () => {
 		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'bar');
 		expect(controller.state).toEqual({
 			addressBook: {
-				'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-					address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-					chainId: 1,
-					memo: '',
-					name: 'bar'
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						memo: '',
+						name: 'bar'
+					}
 				}
 			}
 		});
@@ -73,25 +108,54 @@ describe('AddressBookController', () => {
 		expect(controller.state).toEqual({ addressBook: {} });
 	});
 
-	it('should remove a contact entry', () => {
+	it('should remove one contact entry', () => {
 		const controller = new AddressBookController();
 		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
-		controller.delete('0x32Be343B94f860124dC4fEe278FDCBD38C102D88');
+		controller.delete('1', '0x32Be343B94f860124dC4fEe278FDCBD38C102D88');
+
 		expect(controller.state).toEqual({ addressBook: {} });
 	});
 
-	it('should remove a contact entry', () => {
+	it('should remove only one contact entry', () => {
 		const controller = new AddressBookController();
 		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
 		controller.set('0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d', 'bar');
-		controller.delete('0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d');
+		controller.delete('1', '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d');
+
 		expect(controller.state).toEqual({
 			addressBook: {
-				'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-					address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-					chainId: 1,
-					memo: '',
-					name: 'foo'
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						memo: '',
+						name: 'foo'
+					}
+				}
+			}
+		});
+	});
+
+	it('should add two contact entries with the same chainId', () => {
+		const controller = new AddressBookController();
+		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
+		controller.set('0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d', 'bar');
+
+		expect(controller.state).toEqual({
+			addressBook: {
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						memo: '',
+						name: 'foo'
+					},
+					'0xC38bF1aD06ef69F0c04E29DBeB4152B4175f0A8D': {
+						address: '0xC38bF1aD06ef69F0c04E29DBeB4152B4175f0A8D',
+						chainId: '1',
+						memo: '',
+						name: 'bar'
+					}
 				}
 			}
 		});
@@ -118,27 +182,30 @@ describe('AddressBookController', () => {
 	it('should return true to indicate an address book entry has been deleted', () => {
 		const controller = new AddressBookController();
 		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
-		expect(controller.delete('0x32Be343B94f860124dC4fEe278FDCBD38C102D88')).toBeTruthy();
+		expect(controller.delete('1', '0x32Be343B94f860124dC4fEe278FDCBD38C102D88')).toBeTruthy();
 	});
 
 	it('should return false to indicate an address book entry has NOT been deleted', () => {
 		const controller = new AddressBookController();
 		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
-		expect(controller.delete('bar')).toBeFalsy();
+		expect(controller.delete('1', 'bar')).toBeFalsy();
 	});
 
-	it('should normalize addresses so adding a removing entries work across casings', () => {
+	it('should normalize addresses so adding and removing entries work across casings', () => {
 		const controller = new AddressBookController();
 		controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
-		expect(controller.set('0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d', 'bar')).toBeTruthy();
-		controller.delete('0xC38BF1AD06EF69F0C04E29DBEB4152B4175F0A8D');
+		controller.set('0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d', 'bar');
+
+		controller.delete('1', '0xC38BF1AD06EF69F0C04E29DBEB4152B4175F0A8D');
 		expect(controller.state).toEqual({
 			addressBook: {
-				'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-					address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-					chainId: 1,
-					memo: '',
-					name: 'foo'
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						memo: '',
+						name: 'foo'
+					}
 				}
 			}
 		});

--- a/tests/ComposableController.test.ts
+++ b/tests/ComposableController.test.ts
@@ -112,6 +112,7 @@ describe('ComposableController', () => {
 					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 						chainId: '1',
+						isEns: false,
 						memo: '',
 						name: 'foo'
 					}
@@ -157,6 +158,7 @@ describe('ComposableController', () => {
 						1: {
 							address: 'bar',
 							chainId: '1',
+							isEns: false,
 							memo: '',
 							name: 'foo'
 						}
@@ -182,6 +184,7 @@ describe('ComposableController', () => {
 						'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
 							address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
 							chainId: '1',
+							isEns: false,
 							memo: '',
 							name: 'foo'
 						}

--- a/tests/ComposableController.test.ts
+++ b/tests/ComposableController.test.ts
@@ -108,11 +108,13 @@ describe('ComposableController', () => {
 		addressContext.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
 		expect(controller.flatState).toEqual({
 			addressBook: {
-				'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-					address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-					chainId: 1,
-					memo: '',
-					name: 'foo'
+				1: {
+					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+						chainId: '1',
+						memo: '',
+						name: 'foo'
+					}
 				}
 			},
 			allCollectibleContracts: {},
@@ -152,10 +154,12 @@ describe('ComposableController', () => {
 			AddressBookController: {
 				addressBook: [
 					{
-						address: 'bar',
-						chainId: 1,
-						memo: '',
-						name: 'foo'
+						1: {
+							address: 'bar',
+							chainId: '1',
+							memo: '',
+							name: 'foo'
+						}
 					}
 				]
 			}
@@ -174,11 +178,13 @@ describe('ComposableController', () => {
 		expect(listener.getCall(0).args[0]).toEqual({
 			AddressBookController: {
 				addressBook: {
-					'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-						address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-						chainId: 1,
-						memo: '',
-						name: 'foo'
+					1: {
+						'0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
+							address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
+							chainId: '1',
+							memo: '',
+							name: 'foo'
+						}
 					}
 				}
 			}

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -454,4 +454,14 @@ describe('util', () => {
 			expect(error.message).toBe('timeout');
 		});
 	});
+	describe('isValidEnsName', () => {
+		it('should return if the ens name is valid by current standards', async () => {
+			const valid = util.isValidEnsName('metamask.eth');
+			expect(valid).toBeTruthy();
+		});
+		it('should return if the ens name is invalid by current standards', async () => {
+			const invalid = util.isValidEnsName('me.eth');
+			expect(invalid).toBeFalsy();
+		});
+	});
 });


### PR DESCRIPTION
previously the address book was only keyed by address, so a user was only allowed to have one entry per address regardless of network
