### PR TITLE
Handle unsuccessful fetch

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "gaba",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -726,9 +726,9 @@
       }
     },
     "@types/fetch-mock": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-6.0.5.tgz",
-      "integrity": "sha512-rV8O2j/TIi0PtFCOlK55JnfKpE8Hm6PKFgrUZY/3FNHw4uBEMHnM+5ZickDO1duOyKxbpY3VES5T4NIwZXvodA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.1.tgz",
+      "integrity": "sha512-2U4vZWHNbsbK7TRmizgr/pbKe0FKopcxu+hNDtIBDiM1wvrKRItybaYj7VQ6w/hZJStU/JxRiNi5ww4YDEvKbA==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
@@ -3231,14 +3231,16 @@
       }
     },
     "fetch-mock": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-6.5.2.tgz",
-      "integrity": "sha512-EIvbpCLBTYyDLu4HJiqD7wC8psDwTUaPaWXNKZbhNO/peUYKiNp5PkZGKRJtnTxaPQu71ivqafvjpM7aL+MofQ==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.9.tgz",
+      "integrity": "sha512-PgsTbiQBNapFz2P2UwDl3gowK3nZqfV4HdyDZ1dI4eTGGH9MLAeBglIPbyDbbNQoGYBOfla6/9uaiq7az2z4Aw==",
       "dev": true,
       "requires": {
         "babel-polyfill": "^6.26.0",
+        "core-js": "^2.6.9",
         "glob-to-regexp": "^0.4.0",
-        "path-to-regexp": "^2.2.1"
+        "path-to-regexp": "^2.2.1",
+        "whatwg-url": "^6.5.0"
       }
     },
     "fetch-ponyfill": {

--- a/package.json
+++ b/package.json
@@ -52,14 +52,14 @@
     ]
   },
   "devDependencies": {
-    "@types/fetch-mock": "^6.0.3",
+    "@types/fetch-mock": "^7.3.1",
     "@types/jest": "^22.2.3",
     "@types/node": "^10.1.4",
     "@types/sinon": "^4.3.3",
     "@types/web3": "^1.0.6",
     "@types/xtend": "^4.0.2",
     "ethjs-provider-http": "^0.1.6",
-    "fetch-mock": "^6.4.3",
+    "fetch-mock": "^7.3.9",
     "husky": "^0.14.3",
     "jest": "^24.9.0",
     "jsdom": "11.11.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "lines": 100,
         "statements": 100
       }
-    }
+    },
+    "setupFiles": ["./tests/setupTests.ts"]
   },
   "prettier": {
     "arrowParens": "always",

--- a/src/assets/AssetsContractController.ts
+++ b/src/assets/AssetsContractController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
 const BN = require('ethereumjs-util').BN;

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import AssetsController from './AssetsController';

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 const Mutex = require('await-semaphore').Mutex;
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute } from '../util';

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -1,6 +1,6 @@
 const Mutex = require('await-semaphore').Mutex;
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-import { safelyExecute } from '../util';
+import { safelyExecute, handleFetch } from '../util';
 
 /**
  * @type CurrencyRateConfig
@@ -123,8 +123,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	 * @returns - Promise resolving to exchange rate for given currency
 	 */
 	async fetchExchangeRate(currency: string, nativeCurrency = this.activeNativeCurrency): Promise<CurrencyRateState> {
-		const response = await fetch(this.getPricingURL(currency, nativeCurrency));
-		const json = await response.json();
+		const json = await handleFetch(this.getPricingURL(currency, nativeCurrency));
 		return {
 			conversionDate: Date.now() / 1000,
 			conversionRate: Number(json[currency.toUpperCase()]),

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import AssetsController from './AssetsController';
 import { Token } from './TokenRatesController';

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import AssetsController from './AssetsController';

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -1,7 +1,7 @@
 import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import AssetsController from './AssetsController';
-import { safelyExecute } from '../util';
+import { safelyExecute, handleFetch } from '../util';
 import CurrencyRateController from './CurrencyRateController';
 
 /**
@@ -131,9 +131,7 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
 	 * @returns - Promise resolving to exchange rates for given pairs
 	 */
 	async fetchExchangeRate(query: string): Promise<CoinGeckoResponse> {
-		const response = await fetch(this.getPricingURL(query));
-		const json = await response.json();
-		return json;
+		return handleFetch(this.getPricingURL(query));
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'isomorphic-fetch';
 import * as util from './util';
 
 export * from './assets/AccountTrackerController';

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState, Listener } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';

--- a/src/network/NetworkStatusController.ts
+++ b/src/network/NetworkStatusController.ts
@@ -1,5 +1,5 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-import { safelyExecute } from '../util';
+import { safelyExecute, handleFetch } from '../util';
 
 /**
  * Network status code string
@@ -97,8 +97,7 @@ export class NetworkStatusController extends BaseController<NetworkStatusConfig,
 	 */
 	async updateInfuraStatus(): Promise<NetworkStatus> {
 		try {
-			const response = await fetch('https://api.infura.io/v1/status/metamask');
-			const json = await response.json();
+			const json = await handleFetch('https://api.infura.io/v1/status/metamask');
 			return json && json.mainnet ? json : /* istanbul ignore next */ DOWN_NETWORK_STATUS;
 		} catch (error) {
 			/* istanbul ignore next */

--- a/src/network/NetworkStatusController.ts
+++ b/src/network/NetworkStatusController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute } from '../util';
 

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -1,5 +1,5 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-import { safelyExecute } from '../util';
+import { safelyExecute, handleFetch } from '../util';
 
 const DEFAULT_PHISHING_RESPONSE = require('eth-phishing-detect/src/config.json');
 const PhishingDetector = require('eth-phishing-detect/src/detector');
@@ -126,8 +126,7 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 			return;
 		}
 
-		const response = await fetch('https://api.infura.io/v2/blacklist');
-		const phishing = await response.json();
+		const phishing = await handleFetch('https://api.infura.io/v2/blacklist');
 		this.detector = new PhishingDetector(phishing);
 		phishing && this.update({ phishing });
 	}

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute } from '../util';
 

--- a/src/third-party/ShapeShiftController.ts
+++ b/src/third-party/ShapeShiftController.ts
@@ -1,5 +1,5 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-import { safelyExecute } from '../util';
+import { safelyExecute, handleFetch } from '../util';
 
 /**
  * @type ShapeShiftTransaction
@@ -69,8 +69,7 @@ export class ShapeShiftController extends BaseController<ShapeShiftConfig, Shape
 
 	private async updateTransaction(transaction: ShapeShiftTransaction) {
 		return safelyExecute(async () => {
-			const response = await fetch(this.getUpdateURL(transaction));
-			transaction.response = await response.json();
+			transaction.response = await handleFetch(this.getUpdateURL(transaction));
 			if (transaction.response && transaction.response.status === 'complete') {
 				transaction.time = Date.now();
 			}

--- a/src/third-party/ShapeShiftController.ts
+++ b/src/third-party/ShapeShiftController.ts
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute } from '../util';
 

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -5,6 +5,7 @@ import NetworkController from '../network/NetworkController';
 import {
 	BNToHex,
 	fractionBN,
+	handleFetch,
 	hexToBN,
 	normalizeTransaction,
 	safelyExecute,
@@ -634,8 +635,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		if (fromBlock) {
 			url += `&startBlock=${fromBlock}`;
 		}
-		const response = await fetch(url);
-		const parsedResponse = await response.json();
+		const parsedResponse = await handleFetch(url);
 		/* istanbul ignore else */
 		if (parsedResponse.status !== '0' && parsedResponse.result.length > 0) {
 			const remoteTxList: { [key: string]: number } = {};

--- a/src/util.ts
+++ b/src/util.ts
@@ -289,6 +289,21 @@ export function isSmartContractCode(code: string) {
 }
 
 /**
+ * Execute fetch and verify that the response was successful
+ *
+ * @param request - Request information
+ * @param options - Options
+ * @returns - Promise resolving to the fetch response
+ */
+export async function successfulFetch(request: string, options?: RequestInit) {
+	const response = await fetch(request, options);
+	if (!response.ok) {
+		throw new Error(`Fetch failed with status '${response.status}' for request '${request}'`);
+	}
+	return response;
+}
+
+/**
  * Execute fetch and return object response
  *
  * @param request - Request information
@@ -296,7 +311,7 @@ export function isSmartContractCode(code: string) {
  * @returns - Promise resolving to the result object of fetch
  */
 export async function handleFetch(request: string, options?: RequestInit) {
-	const response = await fetch(request, options);
+	const response = await successfulFetch(request, options);
 	const object = await response.json();
 	return object;
 }
@@ -312,7 +327,7 @@ export async function handleFetch(request: string, options?: RequestInit) {
  */
 export async function timeoutFetch(url: string, options?: RequestInit, timeout: number = 500): Promise<Response> {
 	return Promise.race([
-		fetch(url, options),
+		successfulFetch(url, options),
 		new Promise<Response>((_, reject) =>
 			setTimeout(() => {
 				reject(new Error('timeout'));
@@ -354,6 +369,7 @@ export default {
 	isSmartContractCode,
 	normalizeTransaction,
 	safelyExecute,
+	successfulFetch,
 	timeoutFetch,
 	validateTokenToWatch,
 	validateTransaction,

--- a/tests/CurrencyRateController.test.ts
+++ b/tests/CurrencyRateController.test.ts
@@ -1,14 +1,17 @@
+import 'isomorphic-fetch';
 import { stub } from 'sinon';
+import * as fetchMock from 'fetch-mock';
 import CurrencyRateController from '../src/assets/CurrencyRateController';
 
 describe('CurrencyRateController', () => {
 	beforeEach(() => {
-		const mock = stub(window, 'fetch');
-		mock.resolves({
-			json: () => ({ USD: 1337 })
-		});
-		mock.restore();
+		fetchMock
+			.reset()
+			.mock('*', () => new Response(JSON.stringify({ USD: 1337 })))
+			.spy();
 	});
+
+	afterEach(fetchMock.reset);
 
 	it('should set default state', () => {
 		const controller = new CurrencyRateController();
@@ -79,12 +82,7 @@ describe('CurrencyRateController', () => {
 	it('should use default base asset', async () => {
 		const nativeCurrency = 'FOO';
 		const controller = new CurrencyRateController({ nativeCurrency });
-		const mock = stub(window, 'fetch');
-		mock.resolves({
-			json: () => ({ USD: 1337 })
-		});
 		await controller.fetchExchangeRate('usd');
-		mock.restore();
-		expect(mock.getCall(0).args[0]).toContain(nativeCurrency);
+		expect(fetchMock.calls()[0][0]).toContain(nativeCurrency);
 	});
 });

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,0 +1,1 @@
+import 'isomorphic-fetch';


### PR DESCRIPTION
The `fetch` API will throw an exception if a network error is encountered during a `fetch` invocation, but an unsuccessful response will not. We should never assume that the response from `fetch` is
successful without checking first. We can't even assume that successfully calling `.json()` on a request implies that it succeeded, because failed responses can pass information in the response body as well.

A `successfulFetch` utility method has been added that verifies the fetch response was successful, and throws an error if it was not. This method is now used for the other two `fetch` utility methods, and each instance of `fetch` has been updated to use one of these methods.

New tests have been added for `successfulFetch`. `fetch-mock` was updated to make it easier to specify the status of responses from calls to the mock fetch instance.

Also, 'isomorphic-fetch' has been imported in the index. This ensures that 'isomorphic-fetch' is imported before anything else.

Previously 'isomorphic-fetch' was imported at the beginning of each separate module that used 'fetch', which was needlessly verbose and easy to forget to do (it was missing from one module already).

This would normally break the tests, as the tests don't import modules via the main index file. This was resolved by adding a `setupTests` file that imports `isomorphic-fetch` before running any tests.