### PR TITLE
Setup project for publishing from root folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,11 @@
-.DS_Store
 coverage
 node_modules
+src
+tests
+
+.DS_Store
+.editorconfig
+.nvmrc
+.travis.yml
 npm-debug.log
+ts*

--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,5 @@ tests
 .nvmrc
 .travis.yml
 npm-debug.log
-ts*
+tsconfig.json
+tslint.json

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.7.4",
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "license": "MIT",
+  "main": "./dist/index.js",
   "scripts": {
     "precommit": "lint-staged",
     "lint": "tslint src/**/*.ts",


### PR DESCRIPTION
Updates `.npmignore` and `package.json` to allow for running `npm publish` in project root folder, as opposed to `dist`. This will add our missing readme to NPM.