### PR TITLE
Persist currentCurrency from state when re-initialising controller

### DIFF
--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -65,7 +65,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	constructor(config?: Partial<CurrencyRateConfig>, state?: Partial<CurrencyRateState>) {
 		super(config, state);
 		this.defaultConfig = {
-			currentCurrency: 'usd',
+			currentCurrency: state && state.currentCurrency ? state.currentCurrency : 'usd',
 			disabled: true,
 			interval: 180000,
 			nativeCurrency: 'ETH'

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -44,6 +44,10 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	private mutex = new Mutex();
 	private handle?: NodeJS.Timer;
 
+	private getCurrentCurrencyFromState(state?: Partial<CurrencyRateState>) {
+		return state && state.currentCurrency ? state.currentCurrency : 'usd';
+	}
+
 	private getPricingURL(currentCurrency: string, nativeCurrency: string) {
 		return (
 			`https://min-api.cryptocompare.com/data/price?fsym=` +
@@ -65,7 +69,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	constructor(config?: Partial<CurrencyRateConfig>, state?: Partial<CurrencyRateState>) {
 		super(config, state);
 		this.defaultConfig = {
-			currentCurrency: state && state.currentCurrency ? state.currentCurrency : 'usd',
+			currentCurrency: this.getCurrentCurrencyFromState(state),
 			disabled: true,
 			interval: 180000,
 			nativeCurrency: 'ETH'

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -45,7 +45,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
 	private handle?: NodeJS.Timer;
 
 	private getCurrentCurrencyFromState(state?: Partial<CurrencyRateState>) {
-		return state && state.currentCurrency ? state.currentCurrency : 'usd';
+		return (state && state.currentCurrency) ? state.currentCurrency : 'usd';
 	}
 
 	private getPricingURL(currentCurrency: string, nativeCurrency: string) {

--- a/tests/CurrencyRateController.test.ts
+++ b/tests/CurrencyRateController.test.ts
@@ -33,6 +33,17 @@ describe('CurrencyRateController', () => {
 		});
 	});
 
+	it('should initialize with the currency in state', () => {
+		const existingState = { currentCurrency: 'rep' };
+		const controller = new CurrencyRateController({}, existingState);
+		expect(controller.config).toEqual({
+			currentCurrency: 'rep',
+			disabled: false,
+			interval: 180000,
+			nativeCurrency: 'ETH'
+		});
+	});
+
 	it('should poll and update rate in the right interval', () => {
 		return new Promise((resolve) => {
 			const controller = new CurrencyRateController({ interval: 100 });


### PR DESCRIPTION
re: https://github.com/MetaMask/metamask-extension/issues/6710

re: the pinning, when I installed this I got tsc `Version 3.6.4`

which resulted in the following:

```
src/util.ts:113:4 - error TS2322: Type 'any' is not assignable to type 'never'.

113  		normalizedTransaction[key] = NORMALIZERS[key](transaction[key]);
     		~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

builds fine with `3.5.3`