### PR TITLE
Update project publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,10 +316,13 @@ Linking GABA into other projects involves a special NPM command to ensure that d
 
 ## Release Steps
 
-- Create branch from `develop` named `v${version}`
-- push remote branch
-- Run `npx release <major|minor|patch>`. `major` for breaking changes, `patch` for bugfixes, `minor` for backwards compatible features.
-- Then select which PRs will be added to generate the changelog
+1. Create branch from `develop` named `v${version}`
+2. Run `npm version <major|minor|patch>`
+    - `major` for breaking changes, `patch` for bugfixes, `minor` for backwards compatible features
+3. Push this branch to the remote (with [`--tags`](https://git-scm.com/book/en/v2/Git-Basics-Tagging)!)
+4. Create a PR from that branch targeting `develop`
+5. Create a GitHub Release from the tag
+6. ???
 - Github page will be opened in your browser with the new generated tag and changelog, press the green button to release.
 - Then merge `v${version}` branch to `develop`, then make `master` up to date with `develop`
 - enable "create merge commit" option


### PR DESCRIPTION
This PR updates the project's publishing instructions. (This PR is a draft for conversation sake. 🚧)

I have a few small nitpicks about the current instructions:

- [ ] Do we publish out of the project root or the `dist/` folder?
- [ ] What does `npx release` run? What is it _supposed_ to run?
- [ ] We don't have a changelog, but we do have descriptions for GitHub Releases—we should update the instructions to make this clear

What do y'all think?