### PR TITLE
bugfix: provider stop

### DIFF
--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -133,9 +133,15 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 	}
 
 	private updateProvider(provider: any) {
-		this.provider && this.provider.stop();
+		this.lateProviderStop(provider);
 		this.provider = provider;
 		this.registerProvider();
+	}
+
+	private lateProviderStop(provider: any) {
+		setTimeout(() => {
+			provider && provider.stop();
+		}, 500);
 	}
 
 	private verifyNetwork() {

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -133,7 +133,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 	}
 
 	private updateProvider(provider: any) {
-		this.lateProviderStop(provider);
+		this.lateProviderStop(this.provider);
 		this.provider = provider;
 		this.registerProvider();
 	}

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -133,12 +133,12 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 	}
 
 	private updateProvider(provider: any) {
-		this.lateProviderStop(this.provider);
+		this.safelyStopProvider(this.provider);
 		this.provider = provider;
 		this.registerProvider();
 	}
 
-	private lateProviderStop(provider: any) {
+	private safelyStopProvider(provider: any) {
 		setTimeout(() => {
 			provider && provider.stop();
 		}, 500);


### PR DESCRIPTION
There is a bug happening between stopping the provider listener and setting a new provider.

By doing 
https://github.com/MetaMask/gaba/compare/bugfix/provider-stop?expand=1#diff-e6a23ff500e4183b5eba5bca9a0df0bdL136
we're unsubscribing the provider to handle errors from 
https://github.com/MetaMask/gaba/compare/bugfix/provider-stop?expand=1#diff-e6a23ff500e4183b5eba5bca9a0df0bdL101
causing that we have an active provider exposed to throwable errors without handling it properly.

This PR sets a threshold to stop it after a new provider is set, to make sure that we're not exposed to errors coming from the provider.
