### PR TITLE
Return tx errors correctly

### DIFF
--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -195,7 +195,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 	private failTransaction(transactionMeta: TransactionMeta, error: Error) {
 		transactionMeta.status = 'failed';
 		transactionMeta.error = {
-			message: JSON.stringify(error),
+			message: error.message || JSON.stringify(error),
 			stack: error.stack
 		};
 		this.updateTransaction(transactionMeta);

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -194,10 +194,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 
 	private failTransaction(transactionMeta: TransactionMeta, error: Error) {
 		transactionMeta.status = 'failed';
-		transactionMeta.error = {
-			message: error.message || JSON.stringify(error),
-			stack: error.stack
-		};
+		transactionMeta.error = error;
 		this.updateTransaction(transactionMeta);
 		this.hub.emit(`${transactionMeta.id}:finished`, transactionMeta);
 	}

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -195,7 +195,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 	private failTransaction(transactionMeta: TransactionMeta, error: Error) {
 		transactionMeta.status = 'failed';
 		transactionMeta.error = {
-			message: error.toString(),
+			message: JSON.stringify(error),
 			stack: error.stack
 		};
 		this.updateTransaction(transactionMeta);


### PR DESCRIPTION
We have seen a bunch of  error like this one in mobile that looks like : `"[object Object]`

![Screen Shot 2019-12-13 at 3 40 52 AM](https://user-images.githubusercontent.com/1247834/70786332-6eb77380-1d5a-11ea-8d62-b6ac781aba2d.png)

This is the reason:

![Screen Shot 2019-12-13 at 3 40 07 AM](https://user-images.githubusercontent.com/1247834/70787171-2305c980-1d5c-11ea-9b20-7ea0303c835c.png)

This PR fixes the issue by passing the error object instead.


