### PR TITLE
bugfix: stop speedup txs

### DIFF
--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -460,7 +460,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const existingGasPrice = transactionMeta.transaction.gasPrice;
 		/* istanbul ignore next */
 		const existingGasPriceDecimal = parseInt(existingGasPrice === undefined ? '0x0' : existingGasPrice, 16);
-		const gasPrice = `0x${(existingGasPriceDecimal * CANCEL_RATE).toString(16)}`;
+		const gasPrice = addHexPrefix(`${parseInt(`${existingGasPriceDecimal * CANCEL_RATE}`, 10).toString(16)}`);
 
 		const ethTransaction = new Transaction({
 			from: transactionMeta.transaction.from,
@@ -499,7 +499,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const existingGasPrice = transactionMeta.transaction.gasPrice;
 		/* istanbul ignore next */
 		const existingGasPriceDecimal = parseInt(existingGasPrice === undefined ? '0x0' : existingGasPrice, 16);
-		const gasPrice = `0x${(existingGasPriceDecimal * SPEED_UP_RATE).toString(16)}`;
+		const gasPrice = addHexPrefix(`${parseInt(`${existingGasPriceDecimal * SPEED_UP_RATE}`, 10).toString(16)}`);
 		const ethTransaction = new Transaction({ ...transactionMeta.transaction, gasPrice });
 		await this.sign(ethTransaction, transactionMeta.transaction.from);
 		const rawTransaction = bufferToHex(ethTransaction.serialize());


### PR DESCRIPTION
When users try to stop or cancel txs several times gasPrice is not being handled correctly, this pr makes sure that's going to be always an integer number.