### PR TITLE
Prevent deadlocks resulting from errors thrown before releasing mutex

### DIFF
--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -165,11 +165,9 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
 			preferences.updateIdentities(await privates.get(this).keyring.getAccounts());
 			preferences.update({ selectedAddress: Object.keys(preferences.state.identities)[0] });
 			this.fullUpdate();
-			releaseLock();
 			return vault;
-		} catch (err) /* istanbul ignore next */ {
+		} finally {
 			releaseLock();
-			throw err;
 		}
 	}
 
@@ -187,11 +185,9 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
 			preferences.updateIdentities(await privates.get(this).keyring.getAccounts());
 			preferences.update({ selectedAddress: Object.keys(preferences.state.identities)[0] });
 			this.fullUpdate();
-			releaseLock();
 			return vault;
-		} catch (err) /* istanbul ignore next */ {
+		} finally {
 			releaseLock();
-			throw err;
 		}
 	}
 


### PR DESCRIPTION
A `try ... finally` block has been added to most places where a mutex is used, to ensure that any error thrown before the lock has been released will not result in a deadlock.

The `finally` block will execute after the `try` block, but it will not interfere with any returned values or thrown errors (so long as nothing is thrown or returned within the `finally` block).