### PR TITLE
Update eth-keyring-controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-errors": "^2.0.2",
     "eth-json-rpc-infura": "^4.0.1",
-    "eth-keyring-controller": "^5.6.0",
+    "eth-keyring-controller": "^5.6.1",
     "eth-method-registry": "1.1.0",
     "eth-phishing-detect": "^1.1.13",
     "eth-query": "^2.1.2",
@@ -84,6 +84,10 @@
     },
     "testMatch": [
       "**/*.test.ts"
+    ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "tests/"
     ],
     "coverageThreshold": {
       "global": {

--- a/tests/KeyringController.test.ts
+++ b/tests/KeyringController.test.ts
@@ -5,7 +5,7 @@ import ComposableController from '../src/ComposableController';
 import { KeyringConfig } from '../src/keyring/KeyringController';
 import { stub } from 'sinon';
 const sigUtil = require('eth-sig-util');
-const mockEncryptor: any = require('../node_modules/eth-keyring-controller/test/lib/mock-encryptor.js');
+const mockEncryptor: any = require('../tests/utils/mockEncryptor');
 const Transaction = require('ethereumjs-tx');
 
 const input =

--- a/tests/utils/mockEncryptor.js
+++ b/tests/utils/mockEncryptor.js
@@ -1,0 +1,32 @@
+const sinon = require('sinon')
+
+const mockHex = '0xabcdef0123456789'
+const mockKey = Buffer.alloc(32)
+let cacheVal
+
+module.exports = {
+  encrypt: sinon.stub().callsFake(function (_password, dataObj) {
+    cacheVal = dataObj
+    return Promise.resolve(mockHex)
+  }),
+
+  decrypt (_password, _text) {
+    return Promise.resolve(cacheVal || {})
+  },
+
+  encryptWithKey (key, dataObj) {
+    return this.encrypt(key, dataObj)
+  },
+
+  decryptWithKey (key, text) {
+    return this.decrypt(key, text)
+  },
+
+  keyFromPassword (_password) {
+    return Promise.resolve(mockKey)
+  },
+
+  generateSalt () {
+    return 'WHADDASALT!'
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,10 +1908,10 @@ eth-json-rpc-middleware@^4.1.4, eth-json-rpc-middleware@^4.1.5:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-keyring-controller@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.6.0.tgz#2c851c9b2e6fe5b16285c1a82056577375ac32f4"
-  integrity sha512-KVoC9dGU1V+VrnNJ9DkXgxEYmXPnAbwsLVdKNgiHGEsxk1/y3gO79HFeoWnjZgfapsMm1lTRdjSWW2xYVyreoA==
+eth-keyring-controller@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.6.1.tgz#7b7268400704c8f5ce98a055910341177dd207ca"
+  integrity sha512-sxJ87bJg7PvvPzj1sY1jJYHQL1HVUhh84Q/a4QPrcnzAAng1yibvvUfww0pCez4XJfHuMkJvUxfF8eAusJM8fQ==
   dependencies:
     bip39 "^2.4.0"
     bluebird "^3.5.0"


### PR DESCRIPTION
- `eth-keyring-controller`: `5.6.0` -> `5.6.1`
- Adds `tests/utils` folder and coverage ignore config for `jest`
  - `eth-keyring-controller` no longer exports its tests, and we now redeclare a test helper in `gaba`