### PR TITLE
Remove badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 The **GABA** engine is a collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets.
 
-[![Build Status](https://travis-ci.org/MetaMask/gaba.svg?branch=master)](https://travis-ci.org/MetaMask/gaba)
-[![codecov](https://codecov.io/gh/MetaMask/gaba/branch/master/graph/badge.svg)](https://codecov.io/gh/MetaMask/gaba)
-
 ## Table of Contents
 
 - [Usage](#usage)


### PR DESCRIPTION
This PR removes the badges from the README.

The build status badge isn't useful because 1) we don't use Travis CI anymore (#222) but also because the status is reflected elsewhere on the GH site. The 100% codecov badge isn't important since it is enforced.